### PR TITLE
Feature/non op build 29

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ option(BUILD_UTIL_CONMON "Build Conventional Monitoring Utilities" OFF)
 option(BUILD_UTIL_OZNMON "Build Ozone Monitoring Utilities" OFF)
 option(BUILD_UTIL_RADMON "Build Radiance Monitoring Utilities" OFF)
 
-option(BUILD_UTIL_NCO "Build for NCO -- build only Operational Portions of the Monitor Utilities" ON)
+option(BUILD_UTIL_FOR_NCO "Build only Operational Portions of the Monitor Utilities" OFF)
 
 # If building all monitors, then force all options to ON
 if (BUILD_UTIL_ALLMON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ option(BUILD_UTIL_CONMON "Build Conventional Monitoring Utilities" OFF)
 option(BUILD_UTIL_OZNMON "Build Ozone Monitoring Utilities" OFF)
 option(BUILD_UTIL_RADMON "Build Radiance Monitoring Utilities" OFF)
 
+option(BUILD_UTIL_NCO "Build for NCO -- build only Operational Portions of the Monitor Utilities" ON)
+
 # If building all monitors, then force all options to ON
 if (BUILD_UTIL_ALLMON)
   set(BUILD_UTIL_MINMON ON CACHE BOOL "Build Minimization Monitoring Utilities" FORCE)

--- a/src/Conventional_Monitor/CMakeLists.txt
+++ b/src/Conventional_Monitor/CMakeLists.txt
@@ -1,2 +1,5 @@
-add_subdirectory(image_gen)
+if(NOT ${BUILD_UTIL_NCO})
+   add_subdirectory(image_gen)
+endif()
+
 add_subdirectory(nwprod)

--- a/src/Conventional_Monitor/CMakeLists.txt
+++ b/src/Conventional_Monitor/CMakeLists.txt
@@ -1,5 +1,5 @@
-if(NOT ${BUILD_UTIL_NCO})
+if(NOT ${BUILD_UTIL_FOR_NCO})
    add_subdirectory(image_gen)
+   add_subdirectory(nwprod)
 endif()
 
-add_subdirectory(nwprod)

--- a/src/Ozone_Monitor/CMakeLists.txt
+++ b/src/Ozone_Monitor/CMakeLists.txt
@@ -1,2 +1,5 @@
-add_subdirectory(data_xtrct)
+if(NOT ${BUILD_UTIL_NCO})
+   add_subdirectory(data_xtrct)
+endif()
+
 add_subdirectory(nwprod)

--- a/src/Ozone_Monitor/CMakeLists.txt
+++ b/src/Ozone_Monitor/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(NOT ${BUILD_UTIL_NCO})
+if(NOT ${BUILD_UTIL_FOR_NCO})
    add_subdirectory(data_xtrct)
 endif()
 

--- a/src/Radiance_Monitor/CMakeLists.txt
+++ b/src/Radiance_Monitor/CMakeLists.txt
@@ -1,3 +1,6 @@
-add_subdirectory(data_extract)
-add_subdirectory(image_gen)
+if(NOT ${BUILD_UTIL_NCO})
+   add_subdirectory(data_extract)
+   add_subdirectory(image_gen)
+endif()
+
 add_subdirectory(nwprod)

--- a/src/Radiance_Monitor/CMakeLists.txt
+++ b/src/Radiance_Monitor/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(NOT ${BUILD_UTIL_NCO})
+if(NOT ${BUILD_UTIL_FOR_NCO})
    add_subdirectory(data_extract)
    add_subdirectory(image_gen)
 endif()


### PR DESCRIPTION
While preparing the tag for GFS 16.3 an attempt was made to prune all code/scripts not designed to be included in operations.  Once those sections were pruned though the build failed because cmake was unable to find some of the pruned subdirectories.  

This change adds a BUILD_ONLY_FOR_NCO build option, which, when set to ON, only builds those subdirectories intended to be used in operations.  All other subdirectories are ignored.  