### PR TITLE
Correct use of data_chan.bifix array in radmon_angle.x executable.

### DIFF
--- a/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radang.fd/angle_bias.f90
+++ b/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radang.fd/angle_bias.f90
@@ -392,7 +392,8 @@ program angle
            nbc_omg(2) =  (data_chan(j)%omgnbc)**2
            bc_omg(2)  =  (data_chan(j)%omgbc)**2
 
-           cor_fixang(1) =  data_chan(j)%bifix(angord+1)
+           cor_fixang(1) =  data_chan(j)%bifix(1) + data_chan(j)%bifix(2) + &
+                            data_chan(j)%bifix(3) + data_chan(j)%bifix(4)
            cor_lapse(1)  =  data_chan(j)%bilap
            cor_lapse2(1) =  data_chan(j)%bilap2
            cor_const(1)  =  data_chan(j)%bicons
@@ -413,7 +414,8 @@ program angle
               cor_ordang1(1)   =  0.0
            endif
 
-           cor_fixang(2) =  (data_chan(j)%bifix(angord+1))**2
+           cor_fixang(2) =  (data_chan(j)%bifix(1) + data_chan(j)%bifix(2) + &
+                             data_chan(j)%bifix(3) + data_chan(j)%bifix(4))**2
            cor_lapse(2)  =  (data_chan(j)%bilap)**2
            cor_lapse2(2) =  (data_chan(j)%bilap2)**2
            cor_const(2)  =  (data_chan(j)%bicons)**2


### PR DESCRIPTION
See issue #33 for full description of problem.  

Changes build correctly on wcoss2, hera, and orion.  

Tested using global-workflow running the RadMon via the gdasvrfy job step with necessary data (radstat and abias files) staged in `$comrot`. 