### PR TITLE
Update gdas_oznmon_satype.txt file

### DIFF
--- a/src/Ozone_Monitor/nwprod/gdas_oznmon/fix/gdas_oznmon_satype.txt
+++ b/src/Ozone_Monitor/nwprod/gdas_oznmon/fix/gdas_oznmon_satype.txt
@@ -1,1 +1,1 @@
-gome_metop-b gome_metop-c omi_aura sbuv2_n19 ompsnp_npp ompstc8_npp ompsnp_n20 ompstc8_n20 ompslp_npp ompsnp_n21 ompstc8_n21
+gome_metop-b gome_metop-c omi_aura ompsnp_npp ompstc8_npp ompsnp_n20 ompstc8_n20 ompslp_npp ompsnp_n21 ompstc8_n21


### PR DESCRIPTION
The sbuv_n19 will no longer be providing data and is to be removed from the oznmon's satype.  This completes issue  #43.