### PR TITLE
Update Jet and S4 support

### DIFF
--- a/modulefiles/jet-run.lua
+++ b/modulefiles/jet-run.lua
@@ -1,0 +1,19 @@
+help([[
+]])
+
+prepend_path("MODULEPATH", "/lfs4/HFIP/hfv3gfs/nwprod/hpc-stack/libs/modulefiles/stack")
+
+local hpc_ver=os.getenv("hpc_ver") or "1.1.0"
+local hpc_intel_ver=os.getenv("hpc_intel_ver") or "18.0.5.274"
+local grads_ver=os.getenv("grads_ver") or "2.2.1"
+local prod_util_ver=os.getenv("prod_util_ver") or "1.2.2"
+
+load(pathJoin("hpc", hpc_ver))
+load(pathJoin("hpc-intel", hpc_intel_ver))
+load(pathJoin("grads", grads_ver))
+load(pathJoin("prod_util", prod_util_ver))
+
+load("common-run")
+
+
+whatis("Description: GSI Monitoring run-time environment on Hera.intel")

--- a/modulefiles/jet-run.lua
+++ b/modulefiles/jet-run.lua
@@ -16,4 +16,4 @@ load(pathJoin("prod_util", prod_util_ver))
 load("common-run")
 
 
-whatis("Description: GSI Monitoring run-time environment on Hera.intel")
+whatis("Description: GSI Monitoring run-time environment on Jet")

--- a/modulefiles/s4-run.lua
+++ b/modulefiles/s4-run.lua
@@ -1,0 +1,21 @@
+help([[
+]])
+
+prepend_path("MODULEPATH", "/data/prod/hpc-stack/modulefiles/stack")
+
+local license_ver=os.getenv("license_ver") or "S4"
+local hpc_ver=os.getenv("hpc_ver") or "1.1.0"
+local hpc_intel_ver=os.getenv("hpc_intel_ver") or "18.0.4"
+local grads_ver=os.getenv("grads_ver") or "2.2.1"
+local prod_util_ver=os.getenv("prod_util_ver") or "1.2.2"
+
+load(pathJoin("license_intel", license_ver))
+load(pathJoin("hpc", hpc_ver))
+load(pathJoin("hpc-intel", hpc_intel_ver))
+load(pathJoin("grads", grads_ver))
+load(pathJoin("prod_util", prod_util_ver))
+
+load("common-run")
+
+
+whatis("Description: GSI Monitoring run-time environment on Hera.intel")

--- a/modulefiles/s4-run.lua
+++ b/modulefiles/s4-run.lua
@@ -18,4 +18,4 @@ load(pathJoin("prod_util", prod_util_ver))
 load("common-run")
 
 
-whatis("Description: GSI Monitoring run-time environment on Hera.intel")
+whatis("Description: GSI Monitoring run-time environment on S4")

--- a/parm/Mon_config
+++ b/parm/Mon_config
@@ -53,14 +53,20 @@ case $MY_MACHINE in
       ;;
            
    jet)
-      module use /lfs4/HFIP/hfv3gfs/nwprod/hpc-stack/libs/modulefiles/stack
-      module load hpc/1.1.0 hpc-intel/18.0.5.274 hpc-impi/2018.4.274
-      module load wgrib2/2.0.8
-      module load grads/2.2.1
-      module load prod_util/1.2.2
-
       export SUB=/apps/slurm/default/bin/sbatch
       export SERVICE_PARTITION="service"
+      account="nesdis-rdo2"
+
+      tankdir="/lfs1/NESDIS/nesdis-rdo2/$USER/monitor"
+      ptmp="/lfs1/NESDIS/nesdis-rdo2/$USER/para/ptmp"
+      stmp="/lfs1/NESDIS/nesdis-rdo2/$USER/para/stmp"
+      BATCH_PARTITION="xjet"
+
+      export PARTITION_OZNMON=${PARTITION_OZNMON:-${BATCH_PARTITION}}
+
+      queue=""
+      project=""
+
       ;;
 
    hera)

--- a/parm/Mon_config
+++ b/parm/Mon_config
@@ -41,7 +41,7 @@ case $MY_MACHINE in
    s4)
       export SUB=/usr/bin/sbatch
       export SERVICE_PARTITION="serial"
-      tankdir="/data/users/dhuber/monitor"
+      tankdir="/data/users/$USER/monitor"
       ptmp="/scratch/users/$USER"
       stmp="/scratch/users/$USER"
       queue=""

--- a/parm/Mon_config
+++ b/parm/Mon_config
@@ -30,7 +30,7 @@ export MY_MACHINE=$machine_id
 #         run-time modules.  If the run-time mod idea passes muster
 #         then I'll open an issue for the change to those machines.
 #
-if [[ $MY_MACHINE = "wcoss2" || $MY_MACHINE = "hera" || $MY_MACHINE = "orion" ]]; then
+if [[ $MY_MACHINE = "wcoss2" || $MY_MACHINE = "hera" || $MY_MACHINE = "orion" || $MY_MACHINE = "s4" || $MY_MACHINE = "jet" ]]; then
    source $DIR_ROOT/ush/module-setup.sh
    module use $DIR_ROOT/modulefiles
    module load ${MACHINE_ID}-run
@@ -39,16 +39,14 @@ fi
 
 case $MY_MACHINE in
    s4)
-      module load license_intel
-      module use /data/prod/hpc-stack/modulefiles/stack
-      module load hpc/1.1.0 hpc-intel/18.0.4 hpc-impi/18.0.4
-      module load wgrib2/2.0.8
-      module load grads/2.2.1
-      module load prod_util/1.2.2
-      module load netcdf/4.7.4
-
       export SUB=/usr/bin/sbatch
       export SERVICE_PARTITION="serial"
+      tankdir="/data/users/dhuber/monitor"
+      ptmp="/scratch/users/$USER"
+      stmp="/scratch/users/$USER"
+      queue=""
+      project=""
+      account="star"
 
       #rstprod data is not allowed on S4
       CHGRP_CMD=echo


### PR DESCRIPTION
This adds runtime module files for S4 and Jet and defines default TANKDIRs for each system.  Tested on both systems.  Fixes #42.