### PR TITLE
Update gcc.yml file

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       # Cache spack, compiler and dependencies


### PR DESCRIPTION
After merging PR #47 the gcc ci test is now failing.  The fix is to update the gcc.yml file specifying  ubuntu-20 as the OS version.  This is a short-term fix.  As soon as the spack-stack team is able to fix the underlying problem in ubuntu-22 both ci yml files will be reset to ubuntu-latest.

Completes issue #52 