### PR TITLE
Change the default partition for Jet

### DIFF
--- a/parm/Mon_config
+++ b/parm/Mon_config
@@ -60,7 +60,7 @@ case $MY_MACHINE in
       tankdir="/lfs1/NESDIS/nesdis-rdo2/$USER/monitor"
       ptmp="/lfs1/NESDIS/nesdis-rdo2/$USER/para/ptmp"
       stmp="/lfs1/NESDIS/nesdis-rdo2/$USER/para/stmp"
-      BATCH_PARTITION="xjet"
+      export BATCH_PARTITION="xjet"
 
       export PARTITION_OZNMON=${PARTITION_OZNMON:-${BATCH_PARTITION}}
 

--- a/src/Radiance_Monitor/image_gen/ush/mk_angle_plots.sh
+++ b/src/Radiance_Monitor/image_gen/ush/mk_angle_plots.sh
@@ -255,7 +255,7 @@ while [[ $ctr -le ${satarr_len} ]]; do
 
       elif [[ ${MY_MACHINE} = "jet" ]]; then
          $SUB --account ${ACCOUNT} -n ${itemctr}  -o ${logfile} -D . -J ${jobname} --time=30:00 \
-              -p ${SERVICE_PARTITION} --wrap "srun -l --multi-prog ${cmdfile}"
+              -p ${BATCH_PARTITION} --wrap "srun -l --multi-prog ${cmdfile}"
 
       elif [[ $MY_MACHINE = "wcoss2" ]]; then
 	 if [[ $NUM_CYCLES -gt 140 ]]; then
@@ -342,6 +342,10 @@ for sat in ${big_satlist}; do
       elif [[ $MY_MACHINE = "s4" ]]; then
          $SUB --account ${ACCOUNT} -n $ii  -o ${logfile} -D . -J ${jobname} --time=4:00:00 \
               --wrap "srun -l --multi-prog ${cmdfile}"
+
+      elif [[ $MY_MACHINE = "jet" ]]; then
+         $SUB --account ${ACCOUNT} -n $ii  -o ${logfile} -D . -J ${jobname} --time=4:00:00 \
+              -p ${BATCH_PARTITION} --wrap "srun -l --multi-prog ${cmdfile}"
 
       else
          $SUB --account ${ACCOUNT} -n $ii  -o ${logfile} -D . -J ${jobname} --time=4:00:00 \

--- a/src/Radiance_Monitor/image_gen/ush/mk_bcoef_plots.sh
+++ b/src/Radiance_Monitor/image_gen/ush/mk_bcoef_plots.sh
@@ -165,7 +165,7 @@ elif [[ $MY_MACHINE = "orion" ]]; then
 
 elif [[ $MY_MACHINE = "jet" ]]; then
    $SUB --account $ACCOUNT --ntasks=1 --mem=5g --time=1:00:00 -J ${jobname} \
-        -p ${SERVICE_PARTITION} -o ${logfile} -D . $IG_SCRIPTS/plot_bcoef.sh
+        -p ${BATCH_PARTITION} -o ${logfile} -D . $IG_SCRIPTS/plot_bcoef.sh
 
 elif [[ $MY_MACHINE = "wcoss2" ]]; then
    $SUB -q $JOB_QUEUE -A $ACCOUNT -o ${logfile} -e $R_LOGDIR/plot_bcoef.err -V \

--- a/src/Radiance_Monitor/image_gen/ush/mk_bcor_plots.sh
+++ b/src/Radiance_Monitor/image_gen/ush/mk_bcor_plots.sh
@@ -214,7 +214,7 @@ elif [[ $MY_MACHINE = "orion" ]]; then
 
 elif [[ $MY_MACHINE = "jet" ]]; then
    $SUB --account ${ACCOUNT} -n $ctr  -o ${logfile} -D . -J ${jobname} \
-        -p ${SERVICE_PARTITION} --time=2:00:00 --wrap "srun -l --multi-prog ${cmdfile}"
+        -p ${BATCH_PARTITION} --time=2:00:00 --wrap "srun -l --multi-prog ${cmdfile}"
 
 elif [[ $MY_MACHINE = "wcoss2" ]]; then
    $SUB -q $JOB_QUEUE -A $ACCOUNT -o ${logfile} -e ${R_LOGDIR}/plot_bcor_${suffix}.err \
@@ -271,7 +271,7 @@ for sat in ${bigSATLIST}; do
 
    elif [[ $MY_MACHINE = "jet" ]]; then
       $SUB --account ${ACCOUNT} -n $ctr  -o ${logfile} -D . -J ${jobname} \
-           -p ${RADMON_PARTITION} --time=1:00:00 --wrap "srun -l --multi-prog ${cmdfile}"
+           -p ${BATCH_PARTITION} --time=1:00:00 --wrap "srun -l --multi-prog ${cmdfile}"
 
    elif [[ $MY_MACHINE = "wcoss2" ]]; then
       $SUB -q $JOB_QUEUE -A $ACCOUNT -o ${logfile} -e ${R_LOGDIR}/plot_bcor_${suffix}.err \

--- a/src/Radiance_Monitor/image_gen/ush/mk_horiz_plots.sh
+++ b/src/Radiance_Monitor/image_gen/ush/mk_horiz_plots.sh
@@ -198,9 +198,12 @@ else							# hera|jet|s4
       if [[ ${MY_MACHINE} = "hera" || ${MY_MACHINE} = "s4" ]]; then
          $SUB -A $ACCOUNT -l procs=${ntasks},walltime=0:50:00 -N ${jobname} \
               -V -j oe -o ${logfile} $cmdfile
+      elif [[ ${MY_MACHINE} = "jet" ]]; then
+         $SUB -A $ACCOUNT -l procs=${ntasks},walltime=0:50:00 -N ${jobname} \
+              -p ${BATCH_PARTITION} -V -j oe -o ${logfile} $cmdfile
       else
          $SUB -A $ACCOUNT -l procs=${ntasks},walltime=0:50:00 -N ${jobname} \
-              -p ${RADMON_PARTITION} -V -j oe -o ${logfile} $cmdfile
+              -p ${SERVICE_PARTITION} -V -j oe -o ${logfile} $cmdfile
       fi
    done
 fi

--- a/src/Radiance_Monitor/image_gen/ush/mk_time_plots.sh
+++ b/src/Radiance_Monitor/image_gen/ush/mk_time_plots.sh
@@ -192,7 +192,7 @@ elif [[ ${MY_MACHINE} = "orion" ]]; then
 
 elif [[ ${MY_MACHINE} = "jet" ]]; then
    ${SUB} --account ${ACCOUNT}  --ntasks=1 --mem=5g --time=1:00:00 -J ${jobname} \
-          --partition ${RADMON_PARTITION} -o ${logfile} ${IG_SCRIPTS}/plot_summary.sh
+          --partition ${BATCH_PARTITION} -o ${logfile} ${IG_SCRIPTS}/plot_summary.sh
 
 elif [[ $MY_MACHINE = "wcoss2" ]]; then
    $SUB -q $JOB_QUEUE -A $ACCOUNT -o ${logfile} -e ${R_LOGDIR}/plot_summary.err -V \
@@ -264,7 +264,7 @@ elif [[ $MY_MACHINE = "orion" ]]; then
 
 elif [[ $MY_MACHINE = "jet" ]]; then
    $SUB --account ${ACCOUNT} -n ${ctr}  -o ${logfile} -D . -J ${jobname} --time=1:00:00 \
-        -p ${SERVICE_PARTITION} --wrap "srun -l --multi-prog ${cmdfile}"
+        -p ${BATCH_PARTITION} --wrap "srun -l --multi-prog ${cmdfile}"
 
 elif [[ $MY_MACHINE = "wcoss2" ]]; then
    $SUB -q $JOB_QUEUE -A $ACCOUNT -o ${logfile} -e ${R_LOGDIR}/plot_time_${suffix}.err -V \
@@ -320,7 +320,7 @@ for sat in ${bigSATLIST}; do
 
    elif [[ $MY_MACHINE = "jet" ]]; then
       $SUB --account ${ACCOUNT} -n ${ctr}  -o ${logfile} -D . -J ${jobname} --time=4:00:00 \
-           -p ${SERVICE_PARTITION} --wrap "srun -l --multi-prog ${cmdfile}"
+           -p ${BATCH_PARTITION} --wrap "srun -l --multi-prog ${cmdfile}"
 
    elif [[ $MY_MACHINE = "wcoss2" ]]; then
       logfile=${R_LOGDIR}/plot_time_${sat}.log


### PR DESCRIPTION
When running a few different jobs, the monitors would attempt to submit jobs with more than one task to the service partition.  This would result in jobs not submitting at all.  This is fixed here by specifying that such jobs should be pushed to the BATCH_PARTITION.  Fixes #51.