### PR TITLE
Update modulefiles for wcoss2

### DIFF
--- a/modulefiles/wcoss2-run.lua
+++ b/modulefiles/wcoss2-run.lua
@@ -2,16 +2,16 @@ help([[
 ]])
 
 local intel_ver=os.getenv("intel_ver") or "19.1.3.304"
+local prod_util_ver=os.getenv("prod_util_ver") or "2.0.13"
+local prod_envir_ver=os.getenv("prod_envir_ver") or "2.0.6"
 
 load(pathJoin("intel", intel_ver))
+load(pathJoin("prod_util", prod_util_ver))
+load(pathJoin("prod_envir", prod_envir_ver))
 
 
 prepend_path("MODULEPATH", "/apps/test/lmodules/core/")
 load ("GrADS/2.2.2")
-
-prepend_path("MODULEPATH", "/apps/ops/para/nco/modulefiles/core/")
-load ("prod_util/2.0.13")
-load ("prod_envir/2.0.6")
 
 load("common-run")
 

--- a/modulefiles/wcoss2.lua
+++ b/modulefiles/wcoss2.lua
@@ -4,20 +4,15 @@ help([[
 local PrgEnv_intel_ver=os.getenv("PrgEnv_intel_ver") or "8.1.0"
 local intel_ver=os.getenv("intel_ver") or "19.1.3.304"
 local craype_ver=os.getenv("craype_ver") or "2.7.8"
+local cray_mpich_ver=os.getenv("cray_mpich_ver") or "8.1.7"
 local cmake_ver= os.getenv("cmake_ver") or "3.20.2"
 
 load(pathJoin("PrgEnv-intel", PrgEnv_intel_ver))
 load(pathJoin("intel", intel_ver))
 load(pathJoin("craype", craype_ver))
+load(pathJoin("cray-mpich", cray_mpich_ver))
 load(pathJoin("cmake", cmake_ver))
 
 load("common")
-unload("ncdiag")
-
-pushenv("HPC_OPT", "/apps/ops/para/libs")
-prepend_path("MODULEPATH", "/apps/ops/para/libs/modulefiles/compiler/intel/19.1.3.304")
-prepend_path("MODULEPATH", "/apps/ops/para/libs/modulefiles/mpi/intel/19.1.3.304/cray-mpich/8.1.7")
-
-load("ncdiag/1.0.0")
 
 whatis("Description: GSI Monitoring environment on WCOSS2")

--- a/src/Conventional_Monitor/nwprod/gdas_conmon/jobs/JGDAS_ATMOS_CONMON
+++ b/src/Conventional_Monitor/nwprod/gdas_conmon/jobs/JGDAS_ATMOS_CONMON
@@ -78,7 +78,8 @@ export NDATE=${NDATE:-$utilexec/ndate}
 # TANKDIR_cmon - WHERE OUTPUT DATA WILL RESIDE
 ##############################################################
 export C_TANKDIR=${C_TANKDIR:-/com/verf/${envir}}
-export C_COM_IN=${C_COM_IN:-${COMROOTp3}/${NET}/${envir}}
+export C_COM_IN=${C_COM_IN:-${COMROOT}/${NET}/${envir}}
+
 export C_COMIN=${C_COMIN:-$C_COM_IN/${RUN}.${PDY}}
 export CONMON_SUFFIX=${CONMON_SUFFIX:-gdas}
 


### PR DESCRIPTION
Recently several modules on wcoss2 were updated moving many from para to prod space.  The wcoss2 specific modulefiles have been updated accordingly.   

With these changes building on wcoss2 works as expected, as does monitor functions.  

A related update to `src/Conventional_Monitor/nwprod/gdas_conmon/jobs/JGDAS_ATMOS_CONMON` is included.  It was found to have an old default location for data.

Completes #74 