### PR TITLE
Small cleanup items for RadMon and OznMon

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   setup:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       # Cache spack, compiler and dependencies

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -33,7 +33,7 @@ env:
 
 jobs:
   setup:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       # Cache spack, compiler and dependencies
@@ -79,7 +79,7 @@ jobs:
 
   build:
     needs: setup
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: checkout-gsi-monitor

--- a/src/Ozone_Monitor/image_gen/ush/OznMon_Plt.sh
+++ b/src/Ozone_Monitor/image_gen/ush/OznMon_Plt.sh
@@ -232,7 +232,7 @@ if [[ $pdate -le $last_cycle && -d ${dp} ]]; then
    #--------------------------------------------------------------------
 
    if [[ -e ${OZN_TANKDIR_STATS}/info/gdas_oznmon_satype.txt ]]; then
-      export SATYPE=${SATYPE:-`cat ${OZN_TANKDIR}/info/${RUN}_oznmon_satype.txt`}
+      export SATYPE=${SATYPE:-`cat ${OZN_TANKDIR_STATS}/info/gdas_oznmon_satype.txt`}
    else
       export SATYPE=${SATYPE:-`cat ${HOMEgdas_ozn}/fix/${RUN}_oznmon_satype.txt`}
    fi

--- a/src/Radiance_Monitor/data_extract/ush/radmon_copy.sh
+++ b/src/Radiance_Monitor/data_extract/ush/radmon_copy.sh
@@ -252,6 +252,9 @@ if [[ $exit_value == 0 ]]; then
    rm -f radmon_err_rpt.sh  
 
    nfile_dest=`ls -l ${dest_dir}/*${PDATE}*ieee_d* | egrep -c '^-'`
+   if [[ ${nfile_dest} -le 0 ]]; then
+      nfile_dest=`ls -l ${dest_dir}/radmon_*tar* | egrep -c '^-'`
+   fi
 
    if [[ exit_value -eq 0 && $nfile_src -ne $nfile_dest ]]; then
       exit_value=6 

--- a/src/Radiance_Monitor/data_extract/ush/validate.sh
+++ b/src/Radiance_Monitor/data_extract/ush/validate.sh
@@ -30,7 +30,6 @@ set -ax
    PDATE=$1
 
 
-   sat="sndrd4_g15"
    iyy=`echo $PDATE | cut -c1-4`
    imm=`echo $PDATE | cut -c5-6`
    idd=`echo $PDATE | cut -c7-8`
@@ -44,11 +43,10 @@ set -ax
    if [[ -s ${TANKverf}/info/${base_file} || \
 	 -s ${TANKverf}/info/${base_file}.${Z} ]]; then
       cp ${TANKverf}/info/${base_file}* .
-   fi
-
-   if [[ ! -s ${base_file} && ! -s ${base_file}.${Z} ]]; then
+   else 
       cp ${FIXgdas}/${base_file}* .
    fi
+
    if [[ ! -s ${base_file} && ! -s ${base_file}.${Z} ]]; then
       echo "WARNING:  Unable to locate ${base_file}"
    fi
@@ -60,11 +58,14 @@ set -ax
    tar -xvf ${base_file}
    rm -f ${base_file}
 
-#
-#  Get satype list, loop over satype
-#
-   PDATE=${iyy}${imm}${idd}${ihh}
-   echo PDATE = $PDATE
+   if [[ -e radmon_time.tar.${Z} ]]; then
+      gunzip radmon_time.tar.${Z}
+   fi
+
+   if [[ -e radmon_time.tar ]]; then
+      tar -xvf radmon_time.tar
+      gzip radmon_time.tar
+   fi
 
    test_list=`ls time.*.${PDATE}.ieee_d*`
    for test in ${test_list}; do
@@ -120,10 +121,17 @@ EOF
       ./radmon_validate_tm.x < input >   stdout.validate.$sat.$ihh
 
 
-      ${COMPRESS} time.${sat}.${PDATE}.ieee_d
+      if [[ -e radmon_time.tar || -e radmon_time.tar.${Z} ]]; then
+         rm time.${sat}.${PDATE}.ieee_d
+         rm time.${sat}.ctl
+      else
+         ${COMPRESS} time.${sat}.${PDATE}.ieee_d
+         ${COMPRESS} time.${sat}.ctl.ieee_d
+      fi
 
    done              #  end loop over SATYPE_LIST
 
    rm -f *.base
+   rm -f ./input
 
 echo "<-- end validate.sh"


### PR DESCRIPTION
This PR contains some small cleanup to the RadMon and OznMon.  These are changes I'd made to my local copy some time ago, then got distracted and failed to get into develop.  These are both quality of life items for me (@EdwardSafford-NOAA ) and do not affect developers or global-workflow.  All changes have been tested over the past week and are correctly handling the operational gfs/gdas data and producing the expected plots and warning messages.

The change to `OznMon_Plt.sh` corrects the location of the alternate location for `gdas_oznmon_satype.txt`.  The authoritative satype file is located at  `Ozone_Monitor/nwprod/gdas/fix/gdas_oznmon_satype.txt`.  However, it sometimes contains sources that are anticipated but not yet available, and if used, would produce erroneous warning messages.  A copy of the same file located at `${OZN_TANKDIR_STATS}/info/gdas_oznmon_satype.txt` is to take precedence.  This change corrects the location of the `info `directory.

The changes to `radmon_copy.sh` and `validate.sh` update those files to correctly handle the time series data in a tar file.  Tar files were introduced to the RadMon some time ago in an effort to reduce the number of output data files, which is a real issue on hera.  These two scripts were not fully updated when that change took place.  I'm the only one I'm aware of who uses `radmon_copy.sh`.  It simply copies radmon data from a source (typically operational gdas data) to my local $TANKDIR.  The files are to support both non-tarred and tarred data, which they do with these changes.

Completes #82 