### PR TITLE
Fix error in exnam_vefrad.sh

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -79,7 +79,7 @@ jobs:
 
   build:
     needs: setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: checkout-gsi-monitor

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -33,7 +33,7 @@ env:
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       # Cache spack, compiler and dependencies

--- a/src/Radiance_Monitor/nwprod/nam_radmon/scripts/exnam_verfrad.sh
+++ b/src/Radiance_Monitor/nwprod/nam_radmon/scripts/exnam_verfrad.sh
@@ -112,7 +112,7 @@ if [[ -s ${radstat} && -s ${biascr} ]]; then
 
    for type in ${SATYPE}; do
 
-      if [[ RADMON_NETCDF == ".true." ]]; then
+      if [[ ${RADMON_NETCDF} == ".true." ]]; then
 
          if [[ ! -e ./diag_${type}_ges.${PDATE}.nc4.${Z} ]]; then
             edited_satype="$(echo $SATYPE | tr ' ' '\n' | sed "/${type}/d")"


### PR DESCRIPTION
Fix error in exnam_verfrad.sh.  No idea how testing for #89 missed this but there it is.

The change to `.github/workflow/intel.yml` is an effort to fix the CI failures that started yesterday.  Dropping back to Ubuntu-20.04 rather than 'latest' worked before when CI failures popped up.

Completes #90 