### PR TITLE
Update RadMon transfer scripts to work on hera

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -9,7 +9,7 @@ defaults:
 
 # Set I_MPI_CC/F90 so Intel MPI wrapper uses icc/ifort instead of gcc/gfortran
 env:
-  cache_key: intel4  # The number (#) following the cache_key "intel" is to flush Action cache.
+  cache_key: intel5  # The number (#) following the cache_key "intel" is to flush Action cache.
   CC: icc
   FC: ifort
   CXX: icpc
@@ -33,7 +33,7 @@ env:
 
 jobs:
   setup:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       # Cache spack, compiler and dependencies
@@ -79,7 +79,7 @@ jobs:
 
   build:
     needs: setup
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: checkout-gsi-monitor

--- a/src/Radiance_Monitor/README
+++ b/src/Radiance_Monitor/README
@@ -69,9 +69,9 @@ and run:
                         comrot/$PSLOT directory.  This is only needed if your extraction
                         was via global-workflow and NOT copied to $TANKDIR.
 
-6.  Move the data and html files to the web server (emcrzdm).  If you're on wcoss2 and  
-have set up password free access to web server for your account, RadMon_IG_glb.sh will 
-queue the transfer script and move the files to the server.  
+6.  Move the data and html files to the web server (emcrzdm).  If you're on wcoss2 or 
+hera and have set up password free access to web server for your account, RadMon_IG_glb.sh 
+will queue the transfer script and move the files to the server.  
 
 Alternately the transfer script, RunTransfer.sh, can be run from the command line:
   

--- a/src/Radiance_Monitor/image_gen/ush/RadMon_IG_glb.sh
+++ b/src/Radiance_Monitor/image_gen/ush/RadMon_IG_glb.sh
@@ -324,7 +324,7 @@ ${IG_SCRIPTS}/rm_img_files.pl --dir ${TANKimg}/pngs --nfl 30
 #----------------------------------------------------------------------
 if [[ $RUN_TRANSFER -eq 1 ]]; then
 
-   if [[ $MY_MACHINE = "wcoss2" ]]; then
+   if [[ $MY_MACHINE = "wcoss2" || $MY_MACHINE = "hera" ]]; then
       cmin=`date +%M`		# minute (MM)
       ctime=`date +%G%m%d%H`	# YYYYMMDDHH
       rtime=`$NDATE +1 $ctime`	# ctime + 1 hour

--- a/src/Radiance_Monitor/image_gen/ush/RunTransfer.sh
+++ b/src/Radiance_Monitor/image_gen/ush/RunTransfer.sh
@@ -79,7 +79,8 @@ fi
 
 transfer_queue=dev_transfer
 jobname=transfer_${RADMON_SUFFIX}
-export WEBDIR=${WEBDIR}/${RADMON_SUFFIX}/pngs
+#export WEBDIR=${WEBDIR}/${RADMON_SUFFIX}/pngs
+export WEBDIR=${WEBDIR}/${RADMON_SUFFIX}
 echo WEBDIR  = $WEBDIR
 echo IMGNDIR = $IMGNDIR
 
@@ -92,8 +93,13 @@ cmdfile="${transfer_work_dir}/transfer_cmd"
 echo "${IG_SCRIPTS}/transfer.sh" >$cmdfile
 chmod 755 $cmdfile
 
+if [[ ${MY_MACHINE} = "hera" ]]; then
+   ${SUB} --account ${ACCOUNT}  --ntasks=1 --mem=500M --time=45:00 -J ${jobname} \
+          --partition service -o ${transfer_log} ${IG_SCRIPTS}/transfer.sh
 
-$SUB -q $transfer_queue -A $ACCOUNT -o ${transfer_log} -e ${transfer_err} \
-     -V -l select=1:mem=500M -l walltime=45:00 -N ${jobname} ${cmdfile}
+elif [[ ${MY_MACHINE} = "wcoss2" ]]; then
+   $SUB -q $transfer_queue -A $ACCOUNT -o ${transfer_log} -e ${transfer_err} \
+        -V -l select=1:mem=500M -l walltime=45:00 -N ${jobname} ${cmdfile}
+fi
 
 exit

--- a/src/Radiance_Monitor/image_gen/ush/RunTransfer.sh
+++ b/src/Radiance_Monitor/image_gen/ush/RunTransfer.sh
@@ -79,7 +79,6 @@ fi
 
 transfer_queue=dev_transfer
 jobname=transfer_${RADMON_SUFFIX}
-#export WEBDIR=${WEBDIR}/${RADMON_SUFFIX}/pngs
 export WEBDIR=${WEBDIR}/${RADMON_SUFFIX}
 echo WEBDIR  = $WEBDIR
 echo IMGNDIR = $IMGNDIR

--- a/src/Radiance_Monitor/image_gen/ush/transfer.sh
+++ b/src/Radiance_Monitor/image_gen/ush/transfer.sh
@@ -1,9 +1,35 @@
 #!/bin/bash
 
-if [[ ${IMGNDIR} != "/" ]]; then
+if [[ ${TANKimg} != "/" && -d ${TANKimg} ]]; then
+
+   WEBSVR=${WEBSVR}.ncep.noaa.gov
+
+   #----------------------------------------------------------
+   # If the destination directory exists (on the server) then
+   # sync the html there with the $TANKimg directory so we
+   # have a backup copy.  Note the pngs subdirectory is 
+   # skipped -- we only want to update the html and related
+   # site files in $TANKimg, not the files in /pngs.  Also 
+   # note that the use of the --update option means that if a 
+   # file exists in both places the destination file is not 
+   # updated if it's newer.
+   #
+   # Else create the destintation directory on the server.
+   #----------------------------------------------------------
+
+   if ssh ${WEBUSER}@${WEBSVR} "[ -d ${WEBDIR} ]"; then
+      /usr/bin/rsync -ave ssh --exclude 'pngs/' --update \
+         ${WEBUSER}@${WEBSVR}:${WEBDIR}/ ${TANKimg}
+   else
+      ssh ${WEBUSER}@${WEBSVR} "mkdir -p ${WEBDIR}"
+   fi
+
    /usr/bin/rsync -ave ssh --exclude *.ctl.${Z} \
-      --exclude 'horiz' --exclude *.png --delete-during ${IMGNDIR}/ \
-      ${WEBUSER}@${WEBSVR}.ncep.noaa.gov:${WEBDIR}/
+      --exclude 'horiz' --exclude *.png --delete-during --update ${TANKimg}/ \
+      ${WEBUSER}@${WEBSVR}:${WEBDIR}/
+
+else
+   echo "Unable to run rsync, TANKimg has bad/no value of: ${TANKimg}"
 fi
 
 exit


### PR DESCRIPTION
RadMon file transfer scripts were updated to perform file transfers from hera, if user has password-free access to the web server (emcrzdm).  

The transfer.sh script was also made a bit smarter.  It now:

1.  Checks to see if there is a copy of the html and other web services files in $TANKimg (source directory) and syncs those files with the corresponding server directory.  Any new changes in $TANKimg are not overwritten though.  
2.  Creates the proper directory on the server if it doesn't exist (necessary for initial installation).
3.  Syncs the $TANKimg directory and pngs sub-directory with the corresponding directory on the server. 

Testing has been completed on hera and wcoss2.

Completes #92 