### PR TITLE
Fix RadMon file transfers

### DIFF
--- a/src/Radiance_Monitor/image_gen/html/Install_html.sh
+++ b/src/Radiance_Monitor/image_gen/html/Install_html.sh
@@ -17,7 +17,7 @@ function usage {
   echo "Usage:  Install_html.sh suffix [-t|--tank]"
   echo "            Suffix is data source identifier that matches data in "
   echo "              the $TANKDIR/stats directory."
-  echo "            -t | --tank parent directory to the radnmon data file location.  This"
+  echo "            -t | --tank parent directory to the radmon data file location.  This"
   echo "              will be extended by \$RADMON_SUFFIX, \$RUN, and \$PDATE to locate the"
   echo "              extracted radmon data."
   echo ""

--- a/src/Radiance_Monitor/image_gen/html/README
+++ b/src/Radiance_Monitor/image_gen/html/README
@@ -7,12 +7,14 @@ The transfer mechanism is a password-free, secure log-in using a public/private
 encryption key pair.  There is information on the bottom of the wiki page about 
 how to set that up (see https://svnemc.ncep.noaa.gov/trac/gsi/wiki/RadianceMonitorPackage).
 
-The install script requires two parameters:  the data suffix (identifier) and area.  The 
-suffix is used to access data files from $MY_TANKDIR.  Area must be either 'glb' or 'rgn'
-meaning global or regional.
+The install script requires one parameter:  the data suffix (identifier).  The 
+suffix is used to access data files from $MY_TANKDIR.  If the data source is not in your 
+$MY_TANKDIR location (which it won't be if you're working from a parallel), then use the 
+--tank option to specify the location of the data.  That directory will then be expanded 
+using the suffix, run (gdas), and date.
  
 An example calling sequence is thus:
 
->  ./Install_html.sh newd glb
+>  ./Install_html.sh newd --tank /dir/to/my/data
 
 

--- a/src/Radiance_Monitor/image_gen/ush/RadMon_IG_glb.sh
+++ b/src/Radiance_Monitor/image_gen/ush/RadMon_IG_glb.sh
@@ -344,15 +344,41 @@ if [[ $RUN_TRANSFER -eq 1 ]]; then
 
       transfer_queue=dev_transfer
       jobname=transfer_${RADMON_SUFFIX}
-      export WEBDIR=${WEBDIR}/${RADMON_SUFFIX}/pngs
+      export WEBDIR=${WEBDIR}/${RADMON_SUFFIX}
 
       cmdfile="${PLOT_WORK_DIR}/transfer_cmd"
       echo "${IG_SCRIPTS}/transfer.sh" >$cmdfile
       chmod 755 $cmdfile
 
       run_time="$rhr$cmin"	# HHMM format for qsub
-      $SUB -q $transfer_queue -A $ACCOUNT -o ${transfer_log} -e ${transfer_err} \
-           -V -l select=1:mem=500M -l walltime=45:00 -N ${jobname} -a ${run_time} ${cmdfile}
+#      $SUB -q $transfer_queue -A $ACCOUNT -o ${transfer_log} -e ${transfer_err} \
+#           -V -l select=1:mem=500M -l walltime=45:00 -N ${jobname} -a ${run_time} ${cmdfile}
+
+
+#      transfer_queue=dev_transfer
+#      jobname=transfer_${RADMON_SUFFIX}
+#      export WEBDIR=${WEBDIR}/${RADMON_SUFFIX}
+#      echo WEBDIR  = $WEBDIR
+#      echo IMGNDIR = $IMGNDIR
+#
+#      transfer_work_dir=${MON_STMP}/${RADMON_SUFFIX}/${RUN}/radmon/transfer
+#      if [[ ! -d ${transfer_work_dir} ]]; then
+#	         mkdir -p ${transfer_work_dir}
+#      fi
+#
+#      cmdfile="${transfer_work_dir}/transfer_cmd"
+#      echo "${IG_SCRIPTS}/transfer.sh" >$cmdfile
+#      chmod 755 $cmdfile
+
+      if [[ ${MY_MACHINE} = "hera" ]]; then
+         ${SUB} --account ${ACCOUNT}  --ntasks=1 --mem=500M --time=45:00 -J ${jobname} \
+	        --partition service -o ${transfer_log} --begin=${rhr}:${cmin} ${IG_SCRIPTS}/transfer.sh
+
+      elif [[ ${MY_MACHINE} = "wcoss2" ]]; then
+	 $SUB -q $transfer_queue -A $ACCOUNT -o ${transfer_log} -e ${transfer_err} \
+	      -V -l select=1:mem=500M -l walltime=45:00 -N ${jobname} -a ${run_time} ${cmdfile}
+      fi
+
 
    fi
 fi

--- a/src/Radiance_Monitor/image_gen/ush/RadMon_IG_glb.sh
+++ b/src/Radiance_Monitor/image_gen/ush/RadMon_IG_glb.sh
@@ -350,31 +350,12 @@ if [[ $RUN_TRANSFER -eq 1 ]]; then
       echo "${IG_SCRIPTS}/transfer.sh" >$cmdfile
       chmod 755 $cmdfile
 
-      run_time="$rhr$cmin"	# HHMM format for qsub
-#      $SUB -q $transfer_queue -A $ACCOUNT -o ${transfer_log} -e ${transfer_err} \
-#           -V -l select=1:mem=500M -l walltime=45:00 -N ${jobname} -a ${run_time} ${cmdfile}
-
-
-#      transfer_queue=dev_transfer
-#      jobname=transfer_${RADMON_SUFFIX}
-#      export WEBDIR=${WEBDIR}/${RADMON_SUFFIX}
-#      echo WEBDIR  = $WEBDIR
-#      echo IMGNDIR = $IMGNDIR
-#
-#      transfer_work_dir=${MON_STMP}/${RADMON_SUFFIX}/${RUN}/radmon/transfer
-#      if [[ ! -d ${transfer_work_dir} ]]; then
-#	         mkdir -p ${transfer_work_dir}
-#      fi
-#
-#      cmdfile="${transfer_work_dir}/transfer_cmd"
-#      echo "${IG_SCRIPTS}/transfer.sh" >$cmdfile
-#      chmod 755 $cmdfile
-
       if [[ ${MY_MACHINE} = "hera" ]]; then
          ${SUB} --account ${ACCOUNT}  --ntasks=1 --mem=500M --time=45:00 -J ${jobname} \
 	        --partition service -o ${transfer_log} --begin=${rhr}:${cmin} ${IG_SCRIPTS}/transfer.sh
 
       elif [[ ${MY_MACHINE} = "wcoss2" ]]; then
+         run_time="$rhr$cmin"	# HHMM format for qsub
 	 $SUB -q $transfer_queue -A $ACCOUNT -o ${transfer_log} -e ${transfer_err} \
 	      -V -l select=1:mem=500M -l walltime=45:00 -N ${jobname} -a ${run_time} ${cmdfile}
       fi

--- a/src/Radiance_Monitor/image_gen/ush/transfer.sh
+++ b/src/Radiance_Monitor/image_gen/ush/transfer.sh
@@ -24,8 +24,11 @@ if [[ ${TANKimg} != "/" && -d ${TANKimg} ]]; then
       ssh ${WEBUSER}@${WEBSVR} "mkdir -p ${WEBDIR}"
    fi
 
+   echo "rsync from ${TANKimg}"
+   echo "rysnc to   ${WEBUSER}@${WEBSVR}:${WEBDIR}/"
+
    /usr/bin/rsync -ave ssh --exclude *.ctl.${Z} \
-      --exclude 'horiz' --exclude *.png --delete-during --update ${TANKimg}/ \
+      --exclude 'horiz' --exclude '*.png' --delete-during --update ${TANKimg}/ \
       ${WEBUSER}@${WEBSVR}:${WEBDIR}/
 
 else

--- a/src/Radiance_Monitor/image_gen/ush/transfer.sh
+++ b/src/Radiance_Monitor/image_gen/ush/transfer.sh
@@ -24,9 +24,6 @@ if [[ ${TANKimg} != "/" && -d ${TANKimg} ]]; then
       ssh ${WEBUSER}@${WEBSVR} "mkdir -p ${WEBDIR}"
    fi
 
-   echo "rsync from ${TANKimg}"
-   echo "rysnc to   ${WEBUSER}@${WEBSVR}:${WEBDIR}/"
-
    /usr/bin/rsync -ave ssh --exclude *.ctl.${Z} \
       --exclude 'horiz' --exclude '*.png' --delete-during --update ${TANKimg}/ \
       ${WEBUSER}@${WEBSVR}:${WEBDIR}/


### PR DESCRIPTION
The recent update to the RadMon file transfers missed fully updating `RadMon_IG_glb.sh`, which queues a delayed file transfer after submitting plot jobs.  This is now corrected and has been tested on wcoss2 and hera.  

Additionally, during testing, a bug was found that resulted in `.png` files being removed from the server when they should not have been.  The `transfer.sh` script was modified to correct this.

Lastly unrelated updates have been made to a `README` and `Install_html.sh` files.
Closes #94 