### PR TITLE
Correct RadMon_IG_rgn.sh for recent file transfer update

### DIFF
--- a/src/Radiance_Monitor/image_gen/ush/RadMon_IG_rgn.sh
+++ b/src/Radiance_Monitor/image_gen/ush/RadMon_IG_rgn.sh
@@ -264,7 +264,7 @@ if [[ $RUN_TRANSFER -eq 1 ]]; then
          jobname=transfer_${RADMON_SUFFIX}
          job="${IG_SCRIPTS}/Transfer.sh --nosrc ${RADMON_SUFFIX}"
 
-         export WEBDIR=${WEBDIR}/regional/${RADMON_SUFFIX}/pngs
+         export WEBDIR=${WEBDIR}/regional/${RADMON_SUFFIX}
 
          cmdfile="${PLOT_WORK_DIR}/transfer_cmd"
          echo "${IG_SCRIPTS}/transfer.sh" >$cmdfile


### PR DESCRIPTION
PR #95  missed updating `RadMon_IG_rgn.sh` for the changes to RadMon file transfers.  Fixing that now.

Closes #96.