### PR TITLE
Fix OznMon using oldest control file

### DIFF
--- a/src/Ozone_Monitor/image_gen/ush/mk_summary.sh
+++ b/src/Ozone_Monitor/image_gen/ush/mk_summary.sh
@@ -66,7 +66,7 @@ for ptype in ${data_source}; do
       #         levels, so when nlev = 1 the plot script doesn't work.
       #
       if [[ $type != "omi_aura" && $type != "gome_metop-a" && \
-	    $type != "gome_metop-b" && $type != "ompstc8_npp" ]]; then
+	    $type != "gome_metop-b" && $type != "ompstc8_npp" && $type != "ompstc8_n20" ]]; then
          if [[ ${MY_MACHINE} = "hera" || ${MY_MACHINE} = "jet" ||
                ${MY_MACHINE} = "s4"   || ${MY_MACHINE} = "orion" ]]; then
             echo "${ctr} ${OZN_IG_SCRIPTS}/plot_summary.sh $type $ptype" >> $cmdfile

--- a/src/Ozone_Monitor/image_gen/ush/plot_horiz.sh
+++ b/src/Ozone_Monitor/image_gen/ush/plot_horiz.sh
@@ -44,7 +44,7 @@ while [[ $ctr -le 3 ]]; do
 
    if [[ -d ${tankdir_cdate} ]]; then
 
-      if [[ -e ${tankdir_cdate}/${SATYPE}.${dsrc}.ctl ]]; then 
+      if [[ ! -e ./${SATYPE}.${dsrc}.ctl && -e ${tankdir_cdate}/${SATYPE}.${dsrc}.ctl ]]; then 
          $NCP ${tankdir_cdate}/${SATYPE}.${dsrc}.ctl ./
       fi
 

--- a/src/Ozone_Monitor/image_gen/ush/plot_summary.sh
+++ b/src/Ozone_Monitor/image_gen/ush/plot_summary.sh
@@ -38,8 +38,8 @@ while [[ $ctr -le 120 ]]; do
    tankdir_cdate=${tankdir_cdate}/time
 
    if [[ -d ${tankdir_cdate} ]]; then
-  
-      if [[ -e ${tankdir_cdate}/${SATYPE}.${ptype}.ctl ]]; then
+ 
+      if [[ ! -e ./${SATYPE}.${ptype}.ctl && -e ${tankdir_cdate}/${SATYPE}.${ptype}.ctl ]]; then
          $NCP ${tankdir_cdate}/${SATYPE}.${ptype}.ctl ./
       fi
 

--- a/src/Ozone_Monitor/image_gen/ush/plot_time.sh
+++ b/src/Ozone_Monitor/image_gen/ush/plot_time.sh
@@ -47,7 +47,7 @@ while [[ $ctr -le 119 ]]; do
 
    if [[ -d ${tankdir_cdate} ]]; then
 
-      if [[ -e ${tankdir_cdate}/${SATYPE}.${dsrc}.ctl ]]; then
+      if [[ ! -e ./${SATYPE}.${dsrc}.ctl && -e ${tankdir_cdate}/${SATYPE}.${dsrc}.ctl ]]; then
          $NCP ${tankdir_cdate}/${SATYPE}.${dsrc}.ctl ./
       fi
 


### PR DESCRIPTION
This PR contains two small fixes for OznMon plots.  

1. Added ompstc8_n20 to the summary plot exclusion list.  Summary OznMon plots can only be generated for a few instruments and ompstc8 isn't one of them.
2. In OznMon plots added a check to avoid overwriting the control (*.ctl) files.  Without this check the control file is overwritten as the processing loop steps through the requested cycles in the plot.  This results in the oldest version of the control file being used.  That is both inefficient and means if there are recent changes to the control file, as there were to ompsnp_n20, they are not immediately picked up.  The new check fixes that.  The fix is in use on cactus since 9/23 and Haixia has confirmed the results are correct.
