### PR TITLE
Ref #114

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ GSI Monitoring Tools
 
 These tools monitor the Gridpoint Statistical Interpolation (GSI) package's data assimiliation, detecting 
 and reporting missing data sources, low observational counts, and high penalty values.  These machines 
-are supported:  wcoss2, hera, orion, jet, cheyenne, s4.
+are supported:  wcoss2, hera, orion, jet, s4.
 
 Suite includes:
 ```

--- a/parm/Mon_config
+++ b/parm/Mon_config
@@ -33,7 +33,7 @@ export MY_MACHINE=$machine_id
 if [[ $MY_MACHINE = "wcoss2" || $MY_MACHINE = "hera" || $MY_MACHINE = "orion" || $MY_MACHINE = "s4" || $MY_MACHINE = "jet" ]]; then
    source $DIR_ROOT/ush/module-setup.sh
    module use $DIR_ROOT/modulefiles
-   module load ${MACHINE_ID}-run
+   module load ${MACHINE_ID}.${COMPILER}-run
    module list
 fi
 

--- a/ush/module-setup.sh
+++ b/ush/module-setup.sh
@@ -33,13 +33,6 @@ elif [[ $MACHINE_ID = wcoss2 ]]; then
     # We are on WCOSS2
     module reset
 
-elif [[ $MACHINE_ID = cheyenne* ]] ; then
-    # We are on NCAR Cheyenne
-    if ( ! eval module help > /dev/null 2>&1 ) ; then
-        source /glade/u/apps/ch/modulefiles/default/localinit/localinit.sh
-    fi
-    module purge
-
 elif [[ $MACHINE_ID = stampede* ]] ; then
     # We are on TACC Stampede
     if ( ! eval module help > /dev/null 2>&1 ) ; then


### PR DESCRIPTION
Update `Mon_config` to correctly use renamed module files and remove references to the deactivated  cheyenne machine.

Closes #114 