### PR TITLE
Added debug CMake build type option.

### DIFF
--- a/ush/build.sh
+++ b/ush/build.sh
@@ -28,6 +28,9 @@ module list
 # Collect BUILD Options
 CMAKE_OPTS+=" -DBUILD_UTIL_ALLMON=ON"
 
+# Build type for executables
+CMAKE_OPTS+=" -DCMAKE_BUILD_TYPE=$BUILD_TYPE"
+
 # Install destination for built executables, libraries, CMake Package config
 CMAKE_OPTS+=" -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX"
 


### PR DESCRIPTION
This PR addresses issue #118. The following is accomplished:

- A new CMake option, `CMAKE_BUILD_TYPE=$BUILD_TYPE` has been added such that the GSI monitor package can be built using debug mode.

This is has been tested using the global-workflow build system as demonstrated in global-workflow PR [#2326](https://github.com/NOAA-EMC/global-workflow/pull/2326).