### PR TITLE
Fix use of rgn_find_cycle.pl

### DIFF
--- a/src/Radiance_Monitor/image_gen/ush/RadMon_IG_rgn.sh
+++ b/src/Radiance_Monitor/image_gen/ush/RadMon_IG_rgn.sh
@@ -131,7 +131,7 @@ fi
 last_plot_time=${TANKimg}/last_plot_time
 echo last_plot_time = $last_plot_time
 
-latest_data=`${MON_USH}/rgn_find_cycle.pl --cyc 1 --dir ${TANKverf}`
+latest_data=`${MON_USH}/rgn_find_cycle.pl --dir ${TANKverf} --mon radmon`
 
 if [[ ${pdate} = "" ]]; then
    if [[ -e ${last_plot_time} ]]; then

--- a/ush/rgn_find_cycle.pl
+++ b/ush/rgn_find_cycle.pl
@@ -7,7 +7,7 @@
 #
 #    Arguments:
 #       --dir     : Required string value containing  $TANKdir/$SUFFIX.
-#       --mon     : Optional monitor name, default is conmon.  
+#       --mon     : Optional monitor name, default is radmon.  
 #
 #------------------------------------------------------------------------
 
@@ -50,7 +50,7 @@
    ##------------------------------------------------------------------
 
    my $dir  = '';
-   my $mon  = 'conmon';
+   my $mon  = 'radmon';
 
    GetOptions( 'dir=s' => \$dir,
                'mon:s' => \$mon );


### PR DESCRIPTION
Recently the calling sequence of `rgn_find_cycle.pl` was changed to support both radmon and conmon data.  The use of `rgn_find_cycle.pl` was not updated in `RadMon_IG_rgn.sh`.  This PR fixes that and makes the default use of `rgn_find_cycle.pl` radmon instead of conmon.  Both work, but radmon is the more common use and should therefore be the default case.

Resolves #122 .