### PR TITLE
Fix RadMon's incorrect use of rmiss with obs counts

### DIFF
--- a/src/Radiance_Monitor/image_gen/src/radmon_ig_time.fd/time.f90
+++ b/src/Radiance_Monitor/image_gen/src/radmon_ig_time.fd/time.f90
@@ -190,7 +190,11 @@ program gatime
                 tot_cnt = tot_cnt + cnt(ftyp,cyc,j,k)
              end do
 
-             chi(ftyp,j,k) = (tot_pen/tot_cnt)
+             if( tot_cnt > 0.0 ) then
+                 chi(ftyp,j,k) = (tot_pen/tot_cnt)
+             else
+                 chi(ftyp,j,k) = rmiss
+             end if
          end do
       end do
    end do

--- a/src/Radiance_Monitor/nwprod/nam_radmon/fix/nam_radmon_satype.txt
+++ b/src/Radiance_Monitor/nwprod/nam_radmon/fix/nam_radmon_satype.txt
@@ -1,2 +1,2 @@
-amsua_n18 amsua_n19 atms_npp hirs4_n19 amsua_metop-b iasi_metop-b mhs_metop-b mhs_n19
+amsua_n15 amsua_n18 amsua_n19 atms_npp hirs4_n19 amsua_metop-b iasi_metop-b mhs_metop-b mhs_n19
 

--- a/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radbcoef.fd/bcoef.f90
+++ b/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radbcoef.fd/bcoef.f90
@@ -218,7 +218,6 @@ program bcoef
 
 !       If observation was assimilated, accumulate sum
         if (data_chan(j)%errinv > 1.e-6) then
-!           pen        =  data_chan(j)%errinv*(data_chan(j)%omgbc)**2
            pen        =  (data_chan(j)%errinv*(data_chan(j)%omgbc))**2
            count(j)   = count(j) + 1.0 
            penalty(j) = penalty(j) + pen
@@ -238,7 +237,7 @@ program bcoef
      if (count(j)>0) then
         penalty(j)=penalty(j)/count(j)
      else
-        count(j)=rmiss
+        count(j)=0.0
         penalty(j)=rmiss
      endif
   end do

--- a/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radbcor.fd/bcor.f90
+++ b/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radbcor.fd/bcor.f90
@@ -428,7 +428,7 @@ program bcor
         if (count(j,k)>0) then
            penalty(j,k)=penalty(j,k)/count(j,k)
         else
-           count(j,k)=rmiss
+           count(j,k) = 0.0
            penalty(j,k)=rmiss
         endif
      end do

--- a/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radtime.fd/time.f90
+++ b/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radtime.fd/time.f90
@@ -383,7 +383,7 @@ program time
               endif
 
            else
-              count(j,k)=rmiss
+              count(j,k)=0.0
               penalty(j,k)=rmiss
            endif
 


### PR DESCRIPTION
In some instances the RadMon's data extraction executables  incorrectly use rmiss (-999.0) instead of 0 when there are no obs counts for a given channel.  

Testing has been done with the NAM.  The summary plots show obs counts of 0 instead of rmiss.

Unrelated the nam's satype file has been updated to reflect current data ingest.

Completes #125 