### PR TITLE
Use Perl v5.38.0 on Hera/Rocky 8

### DIFF
--- a/modulefiles/hera.gnu-run.lua
+++ b/modulefiles/hera.gnu-run.lua
@@ -7,6 +7,7 @@ local stack_gnu_ver=os.getenv("stack_gnu_ver") or "9.2.0"
 local stack_openmpi_ver=os.getenv("stack_openmpi_ver") or "4.1.5"
 local prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
 local grads_ver=os.getenv("grads_ver") or "2.2.1"
+local perl_ver=os.getenv("perl_ver") or "5.38.0"
 
 load(pathJoin("stack-gcc", stack_gnu_ver))
 load(pathJoin("stack-openmpi", stack_openmpi_ver))

--- a/modulefiles/hera.gnu-run.lua
+++ b/modulefiles/hera.gnu-run.lua
@@ -6,7 +6,7 @@ prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-s
 local stack_gnu_ver=os.getenv("stack_gnu_ver") or "9.2.0"
 local stack_openmpi_ver=os.getenv("stack_openmpi_ver") or "4.1.5"
 local prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
-local grads_ver=os.getenv("grads_ver") or "2.2.1"
+local grads_ver=os.getenv("grads_ver") or "2.2.3"
 local perl_ver=os.getenv("perl_ver") or "5.38.0"
 
 load(pathJoin("stack-gcc", stack_gnu_ver))

--- a/modulefiles/hera.intel-run.lua
+++ b/modulefiles/hera.intel-run.lua
@@ -6,7 +6,7 @@ prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-s
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"
 local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.5.1"
 local grads_ver=os.getenv("grads_ver") or "2.2.1"
-local perl_ver=os.getenv("grads_ver") or "5.38.0"
+local perl_ver=os.getenv("perl_ver") or "5.38.0"
 local prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
 
 load(pathJoin("stack-intel", stack_intel_ver))

--- a/modulefiles/hera.intel-run.lua
+++ b/modulefiles/hera.intel-run.lua
@@ -6,6 +6,7 @@ prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-s
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"
 local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.5.1"
 local grads_ver=os.getenv("grads_ver") or "2.2.1"
+local perl_ver=os.getenv("grads_ver") or "5.38.0"
 local prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
 
 load(pathJoin("stack-intel", stack_intel_ver))

--- a/modulefiles/hera.intel-run.lua
+++ b/modulefiles/hera.intel-run.lua
@@ -5,7 +5,7 @@ prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-s
 
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"
 local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.5.1"
-local grads_ver=os.getenv("grads_ver") or "2.2.1"
+local grads_ver=os.getenv("grads_ver") or "2.2.3"
 local perl_ver=os.getenv("perl_ver") or "5.38.0"
 local prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
 


### PR DESCRIPTION
This load the peral/5.38.0 module on Hera Rocky 8.  This is only needed for the minimization monitor within the global workflow (NOAA-EMC/global-workflow#2439), but it seems wise to have the same module loaded within the monitor itself for consistency.