### PR TITLE
Update Jet modulefiles to Rocky8

### DIFF
--- a/modulefiles/jet.intel-run.lua
+++ b/modulefiles/jet.intel-run.lua
@@ -5,7 +5,8 @@ prepend_path("MODULEPATH", "/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-s
 
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"
 local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.5.1"
-local grads_ver=os.getenv("grads_ver") or "2.2.1"
+local grads_ver=os.getenv("grads_ver") or "2.2.3"
+local perl_ver=os.getenv("perl_ver") or "5.38.0"
 local prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
 
 load(pathJoin("stack-intel", stack_intel_ver))

--- a/modulefiles/jet.intel-run.lua
+++ b/modulefiles/jet.intel-run.lua
@@ -1,7 +1,7 @@
 help([[
 ]])
 
-prepend_path("MODULEPATH", "/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev-rocky8/install/modulefiles/Core")
 
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"
 local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.5.1"

--- a/modulefiles/jet.intel.lua
+++ b/modulefiles/jet.intel.lua
@@ -1,7 +1,7 @@
 help([[
 ]])
 
-prepend_path("MODULEPATH", "/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev-rocky8/install/modulefiles/Core")
 
 local stack_python_ver=os.getenv("stack_python_ver") or "3.11.6"
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"


### PR DESCRIPTION
**Description**

- Jet has been upgraded to the Rocky8 Linux OS and present module file no longer works
- Update Jet module file to use Rocky8 installation of spack-stack;

Fixes #130
Refs NOAA-EMC/global-workflow#2377, NOAA-EMC/global-workflow#2458


**How Has This Been Tested?**

This change affects only Jet, there is no need to test on other systems

Cycled experiments (48+ hours) at resolutions
- [x] 96/48 on xjet and kjet
- [x] 192/96 on kjet
- [x] 384/192 on kjet