### PR TITLE
Ref #133

### DIFF
--- a/src/Conventional_Monitor/image_gen/ush/mk_horz_hist.sh
+++ b/src/Conventional_Monitor/image_gen/ush/mk_horz_hist.sh
@@ -34,10 +34,10 @@
 
 
 
-   export nreal_ps=${nreal_ps:-17}
-   export nreal_q=${nreal_q:-18}
-   export nreal_t=${nreal_t:-22}
-   export nreal_uv=${nreal_uv:-21}
+   export nreal_ps=${nreal_ps:-18} 
+   export nreal_q=${nreal_q:-19} 
+   export nreal_t=${nreal_t:-18} 
+   export nreal_uv=${nreal_uv:-23}
 
 
    #------------------------------


### PR DESCRIPTION
Modify expected nreal values for ConMon data files.  Testing over the last 4 production cycles on wcoss2 indicates this fixes the problem with empty histogram plots.

At some point recently the ConMon's histogram plots stopped working. The cause of this problem is in` image_gen/ush/mk_horz_hist.sh` where the expected number of reals in the extracted data file is set for each obs type.   These values are then used to compare with the actual observation contents in the extracted data files and execution halts if there is a difference.  See #133 for more info.

Resolves #133 
