### PR TITLE
Update module files to build gsi_monitor on Gaea-C5

### DIFF
--- a/modulefiles/gaea.intel-run.lua
+++ b/modulefiles/gaea.intel-run.lua
@@ -1,0 +1,18 @@
+help([[
+]])
+
+prepend_path("MODULEPATH", "/ncrc/proj/epic/spack-stack/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core")
+
+local stack_intel_ver=os.getenv("stack_intel_ver") or "2023.1.0"
+local stack_cray_mpich_ver=os.getenv("stack_cray_mpich_ver") or "8.1.25"
+local grads_ver=os.getenv("grads_ver") or "2.0.2"
+local prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
+
+load(pathJoin("stack-intel", stack_intel_ver))
+load(pathJoin("stack-cray-mpich", stack_cray_mpich_ver))
+load(pathJoin("grads", grads_ver))
+load(pathJoin("prod_util", prod_util_ver))
+
+load("common-run")
+
+whatis("Description: GSI Monitoring run-time environment on Hera.intel")

--- a/modulefiles/gaea.intel.lua
+++ b/modulefiles/gaea.intel.lua
@@ -1,0 +1,16 @@
+help([[
+]])
+
+prepend_path("MODULEPATH", "/ncrc/proj/epic/spack-stack/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core")
+
+local stack_intel_ver=os.getenv("stack_intel_ver") or "2023.1.0"
+local stack_cray_mpich_ver=os.getenv("stack_cray_mpich_ver") or "8.1.25"
+local cmake_ver=os.getenv("cmake_ver") or "3.23.1"
+
+load(pathJoin("stack-intel", stack_intel_ver))
+load(pathJoin("stack-cray-mpich", stack_cray_mpich_ver))
+load(pathJoin("cmake", cmake_ver))
+
+load("common")
+
+whatis("Description: GSI Monitoring environment on Gaea with Intel Compilers")

--- a/ush/module-setup.sh
+++ b/ush/module-setup.sh
@@ -73,6 +73,13 @@ elif [[ $MACHINE_ID = discover* ]]; then
     export PATH=$PATH:$SPACK_ROOT/bin
     . $SPACK_ROOT/share/spack/setup-env.sh
 
+elif [[ $MACHINE_ID = noaacloud* ]]; then
+    # We are on NOAA Cloud
+    if ( ! eval module help > /dev/null 2>&1 ) ; then
+        source /apps/lmod/8.5.2/init/bash
+    fi
+    module purge
+
 else
     echo WARNING: UNKNOWN PLATFORM 1>&2
 fi

--- a/ush/module-setup.sh
+++ b/ush/module-setup.sh
@@ -56,33 +56,8 @@ elif [[ $MACHINE_ID = gaea* ]] ; then
         # the module command fails.  Hence we actually have to source
         # /etc/profile here.
         source /etc/profile
-        __ms_source_etc_profile=yes
-    else
-        __ms_source_etc_profile=no
     fi
-    module purge
-    # clean up after purge
-    unset _LMFILES_
-    unset _LMFILES_000
-    unset _LMFILES_001
-    unset LOADEDMODULES
-    module load modules
-    if [[ -d /opt/cray/ari/modulefiles ]] ; then
-        module use -a /opt/cray/ari/modulefiles
-    fi
-    if [[ -d /opt/cray/pe/ari/modulefiles ]] ; then
-        module use -a /opt/cray/pe/ari/modulefiles
-    fi
-    if [[ -d /opt/cray/pe/craype/default/modulefiles ]] ; then
-        module use -a /opt/cray/pe/craype/default/modulefiles
-    fi
-    if [[ -s /etc/opt/cray/pe/admin-pe/site-config ]] ; then
-        source /etc/opt/cray/pe/admin-pe/site-config
-    fi
-    if [[ "$__ms_source_etc_profile" == yes ]] ; then
-        source /etc/profile
-        unset __ms_source_etc_profile
-    fi
+    module reset
 
 elif [[ $MACHINE_ID = expanse* ]]; then
     # We are on SDSC Expanse
@@ -97,13 +72,6 @@ elif [[ $MACHINE_ID = discover* ]]; then
     export SPACK_ROOT=/discover/nobackup/mapotts1/spack
     export PATH=$PATH:$SPACK_ROOT/bin
     . $SPACK_ROOT/share/spack/setup-env.sh
-
-elif [[ $MACHINE_ID = noaacloud* ]]; then
-    # We are on NOAA Cloud
-    if ( ! eval module help > /dev/null 2>&1 ) ; then
-        source /apps/lmod/8.5.2/init/bash
-    fi
-    module purge
 
 else
     echo WARNING: UNKNOWN PLATFORM 1>&2


### PR DESCRIPTION
Update module files to build gsi_monitor on Gaea-C5
add modulefiles/gaea.intel.lua
modify ush/module-setup.sh

Ref #138 
Cross Ref NOAA-EMC/global-workflow/issues/2535