### PR TITLE
Use contrib installation of spack-stack on Jet

### DIFF
--- a/modulefiles/jet.intel-run.lua
+++ b/modulefiles/jet.intel-run.lua
@@ -1,7 +1,7 @@
 help([[
 ]])
 
-prepend_path("MODULEPATH", "/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev-rocky8/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.6.0/envs/gsi-addon-intel/install/modulefiles/Core")
 
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"
 local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.5.1"

--- a/modulefiles/jet.intel.lua
+++ b/modulefiles/jet.intel.lua
@@ -1,7 +1,7 @@
 help([[
 ]])
 
-prepend_path("MODULEPATH", "/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev-rocky8/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.6.0/envs/gsi-addon-intel/install/modulefiles/Core")
 
 local stack_python_ver=os.getenv("stack_python_ver") or "3.11.6"
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.5.0"


### PR DESCRIPTION
# Description
- Update Jet module file to use /contrib installation of spack-stack;
- Following the failure of the lfs4 storage, spack stack was moved to /contrib and present module file no longer works

  Resolves #143
  Refs NOAA-EMC/global-workflow#2841