### PR TITLE
Add/fix build capability for Gaea-C5, Gaea-C6, and container

### DIFF
--- a/modulefiles/container.intel.lua
+++ b/modulefiles/container.intel.lua
@@ -1,0 +1,16 @@
+help([[
+]])
+
+prepend_path("MODULEPATH", "/opt/spack-stack/spack-stack-1.8.0/envs/unified-env/install/modulefiles/Core")
+
+local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.10.0"
+local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.12.2"
+local cmake_ver=os.getenv("cmake_ver") or "3.27.9"
+
+load(pathJoin("stack-intel", stack_intel_ver))
+load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
+load(pathJoin("cmake", cmake_ver))
+
+load("common")
+
+whatis("Description: GSI Monitoring environment using a container with Intel Compilers")

--- a/modulefiles/gaeac5.intel-run.lua
+++ b/modulefiles/gaeac5.intel-run.lua
@@ -3,8 +3,8 @@ help([[
 
 prepend_path("MODULEPATH", "/ncrc/proj/epic/spack-stack/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core")
 
-local stack_intel_ver=os.getenv("stack_intel_ver") or "2023.1.0"
-local stack_cray_mpich_ver=os.getenv("stack_cray_mpich_ver") or "8.1.25"
+local stack_intel_ver=os.getenv("stack_intel_ver") or "2023.2.0"
+local stack_cray_mpich_ver=os.getenv("stack_cray_mpich_ver") or "8.1.28"
 local grads_ver=os.getenv("grads_ver") or "2.0.2"
 local prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
 
@@ -15,4 +15,4 @@ load(pathJoin("prod_util", prod_util_ver))
 
 load("common-run")
 
-whatis("Description: GSI Monitoring run-time environment on Hera.intel")
+whatis("Description: GSI Monitoring run-time environment on GaeaC5.intel")

--- a/modulefiles/gaeac5.intel.lua
+++ b/modulefiles/gaeac5.intel.lua
@@ -3,8 +3,8 @@ help([[
 
 prepend_path("MODULEPATH", "/ncrc/proj/epic/spack-stack/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core")
 
-local stack_intel_ver=os.getenv("stack_intel_ver") or "2023.1.0"
-local stack_cray_mpich_ver=os.getenv("stack_cray_mpich_ver") or "8.1.25"
+local stack_intel_ver=os.getenv("stack_intel_ver") or "2023.2.0"
+local stack_cray_mpich_ver=os.getenv("stack_cray_mpich_ver") or "8.1.28"
 local cmake_ver=os.getenv("cmake_ver") or "3.23.1"
 
 load(pathJoin("stack-intel", stack_intel_ver))
@@ -13,4 +13,4 @@ load(pathJoin("cmake", cmake_ver))
 
 load("common")
 
-whatis("Description: GSI Monitoring environment on Gaea with Intel Compilers")
+whatis("Description: GSI Monitoring environment on GaeaC5 with Intel Compilers")

--- a/modulefiles/gaeac6.intel-run.lua
+++ b/modulefiles/gaeac6.intel-run.lua
@@ -1,0 +1,18 @@
+help([[
+]])
+
+prepend_path("MODULEPATH", "/ncrc/proj/epic/spack-stack/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core")
+
+local stack_intel_ver=os.getenv("stack_intel_ver") or "2023.2.0"
+local stack_cray_mpich_ver=os.getenv("stack_cray_mpich_ver") or "8.1.28"
+local grads_ver=os.getenv("grads_ver") or "2.0.2"
+local prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
+
+load(pathJoin("stack-intel", stack_intel_ver))
+load(pathJoin("stack-cray-mpich", stack_cray_mpich_ver))
+load(pathJoin("grads", grads_ver))
+load(pathJoin("prod_util", prod_util_ver))
+
+load("common-run")
+
+whatis("Description: GSI Monitoring run-time environment on GaeaC6.intel")

--- a/modulefiles/gaeac6.intel-run.lua
+++ b/modulefiles/gaeac6.intel-run.lua
@@ -1,10 +1,10 @@
 help([[
 ]])
 
-prepend_path("MODULEPATH", "/ncrc/proj/epic/spack-stack/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/ncrc/proj/epic/spack-stack/c6/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core")
 
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2023.2.0"
-local stack_cray_mpich_ver=os.getenv("stack_cray_mpich_ver") or "8.1.28"
+local stack_cray_mpich_ver=os.getenv("stack_cray_mpich_ver") or "8.1.29"
 local grads_ver=os.getenv("grads_ver") or "2.0.2"
 local prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
 

--- a/modulefiles/gaeac6.intel.lua
+++ b/modulefiles/gaeac6.intel.lua
@@ -1,0 +1,16 @@
+help([[
+]])
+
+prepend_path("MODULEPATH", "/ncrc/proj/epic/spack-stack/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core")
+
+local stack_intel_ver=os.getenv("stack_intel_ver") or "2023.2.0"
+local stack_cray_mpich_ver=os.getenv("stack_cray_mpich_ver") or "8.1.28"
+local cmake_ver=os.getenv("cmake_ver") or "3.23.1"
+
+load(pathJoin("stack-intel", stack_intel_ver))
+load(pathJoin("stack-cray-mpich", stack_cray_mpich_ver))
+load(pathJoin("cmake", cmake_ver))
+
+load("common")
+
+whatis("Description: GSI Monitoring environment on GaeaC6 with Intel Compilers")

--- a/modulefiles/gaeac6.intel.lua
+++ b/modulefiles/gaeac6.intel.lua
@@ -1,10 +1,10 @@
 help([[
 ]])
 
-prepend_path("MODULEPATH", "/ncrc/proj/epic/spack-stack/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/ncrc/proj/epic/spack-stack/c6/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core")
 
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2023.2.0"
-local stack_cray_mpich_ver=os.getenv("stack_cray_mpich_ver") or "8.1.28"
+local stack_cray_mpich_ver=os.getenv("stack_cray_mpich_ver") or "8.1.29"
 local cmake_ver=os.getenv("cmake_ver") or "3.23.1"
 
 load(pathJoin("stack-intel", stack_intel_ver))

--- a/ush/detect_machine.sh
+++ b/ush/detect_machine.sh
@@ -21,8 +21,11 @@ case $(hostname -f) in
   dlogin0[1-9].dogwood.wcoss2.ncep.noaa.gov) MACHINE_ID=wcoss2 ;; ### dogwood01-9
   dlogin10.dogwood.wcoss2.ncep.noaa.gov)     MACHINE_ID=wcoss2 ;; ### dogwood10
 
-  gaea5[1-8])          MACHINE_ID=gaea ;; ### gaea51-58
-  gaea5[1-8].ncrc.gov) MACHINE_ID=gaea ;; ### gaea51-58
+  gaea5[1-8])          MACHINE_ID=gaeac5 ;; ### gaea51-58
+  gaea5[1-8].ncrc.gov) MACHINE_ID=gaeac5 ;; ### gaea51-58
+
+  gaea6[1-8])          MACHINE_ID=gaeac6 ;; ### gaea61-68
+  gaea6[1-8].ncrc.gov) MACHINE_ID=gaeac6 ;; ### gaea61-68
 
   hfe0[1-9]) MACHINE_ID=hera ;; ### hera01-09
   hfe1[0-2]) MACHINE_ID=hera ;; ### hera10-12
@@ -81,9 +84,12 @@ elif [[ -d /work ]]; then
   else
     MACHINE_ID=orion
   fi
-elif [[ -d /gpfs && -d /ncrc ]]; then
-  # We are on GAEA.
-  MACHINE_ID=gaea
+elif [[ -d /gpfs/f5 ]]; then
+  # We are on GAEAC5.
+  MACHINE_ID=gaeac5
+elif [[ -d /gpfs/f6 ]]; then
+  # We are on GAEAC6.
+  MACHINE_ID=gaeac6
 elif [[ -d /data/prod ]]; then
   # We are on SSEC's S4
   MACHINE_ID=s4

--- a/ush/detect_machine.sh
+++ b/ush/detect_machine.sh
@@ -64,7 +64,10 @@ if [[ "${MACHINE_ID}" != "UNKNOWN" ]]; then
 fi
 
 # Try searching based on paths since hostname may not match on compute nodes
-if [[ -d /lfs/h3 ]]; then
+if [[ -d /opt/spack-stack ]]; then
+  # We are  in a container
+  MACHINE_ID=container
+elif [[ -d /lfs/h3 ]]; then
   # We are on NOAA Cactus or Dogwood
   MACHINE_ID=wcoss2
 elif [[ -d /lfs/h1 && ! -d /lfs/h3 ]]; then

--- a/ush/module-setup.sh
+++ b/ush/module-setup.sh
@@ -22,6 +22,13 @@ elif [[ $MACHINE_ID = orion* ]] ; then
     fi
     module purge
 
+elif [[ $MACHINE_ID = container* ]] ; then
+    # We are in a container
+    if ( ! eval module help > /dev/null 2>&1 ) ; then
+        source /usr/lmod/lmod/init/bash
+    fi
+    module purge
+
 elif [[ $MACHINE_ID = hercules* ]] ; then
     # We are on Hercules
     if ( ! eval module help > /dev/null 2>&1 ) ; then


### PR DESCRIPTION
After the recent Gaea-C5 OS upgrade, gsi-monitor fails to build.
This issues corrects Gaea-C5 build, adds Gaea-C6 build capability (following the ufs-wx-model [PR2448](https://github.com/ufs-community/ufs-weather-model/pull/2448)), and adds containerized build capability.

Refs NOAA-EMC/global-workflow [3011](https://github.com/NOAA-EMC/global-workflow/issues/3011)
Refs NOAA-EMC/global-workflow [3025](https://github.com/NOAA-EMC/global-workflow/issues/3025)
Closes #145 