### PR TITLE
Add disclaimers to the RadMon html template files

### DIFF
--- a/src/Radiance_Monitor/image_gen/html/intro.html
+++ b/src/Radiance_Monitor/image_gen/html/intro.html
@@ -281,4 +281,13 @@ Click on the thumbnail to see the full image
 
 </tr>
 </table>
+
+<footer>
+    <P style="background-color: lightblue;"><u><b>Disclaimer:</b></u> These are not official 
+         NWS products and should not to be relied upon for operational purposes. This web 
+	 site is not subject to 24/7 support, and thus may be unavailable during system 
+	 outages. For more information please see this
+        <a href="https://www.weather.gov/disclaimer.php">Disclaimer</a>
+    </P>
+</footer>
 </html>

--- a/src/Radiance_Monitor/image_gen/html/plot_angle.html
+++ b/src/Radiance_Monitor/image_gen/html/plot_angle.html
@@ -1502,4 +1502,14 @@
 
 
 </body>
+
+<footer>
+    <P style="background-color: lightblue;"><u><b>Disclaimer:</b></u> These are not official 
+             NWS products and should not to be relied upon for operational purposes. This web 
+             site is not subject to 24/7 support, and thus may be unavailable during system 
+             outages. For more information please see this
+             <a href="https://www.weather.gov/disclaimer.php">Disclaimer</a>
+    </P>
+</footer>
+
 </html>

--- a/src/Radiance_Monitor/image_gen/html/plot_bcoef.html
+++ b/src/Radiance_Monitor/image_gen/html/plot_bcoef.html
@@ -1079,6 +1079,14 @@
     <i> assimilated</i>
 </label>
 
+<footer>
+    <P style="background-color: lightblue;"><u><b>Disclaimer:</b></u> These are not official
+              NWS products and should not to be relied upon for operational purposes. This web
+              site is not subject to 24/7 support, and thus may be unavailable during system
+              outages. For more information please see this
+              <a href="https://www.weather.gov/disclaimer.php">Disclaimer</a>
+    </P>
+</footer>
 
 
 </BODY></HTML>

--- a/src/Radiance_Monitor/image_gen/html/plot_summary.html
+++ b/src/Radiance_Monitor/image_gen/html/plot_summary.html
@@ -1172,4 +1172,14 @@
         </table>
 
     </BODY>
+
+    <footer>
+        <P style="background-color: lightblue;"><u><b>Disclaimer:</b></u> These are not official
+ 	          NWS products and should not to be relied upon for operational purposes. This web
+                  site is not subject to 24/7 support, and thus may be unavailable during system
+		  outages. For more information please see this
+		  <a href="https://www.weather.gov/disclaimer.php">Disclaimer</a>
+        </P>
+    </footer>
+
 </HTML>

--- a/src/Radiance_Monitor/image_gen/html/plot_time.html
+++ b/src/Radiance_Monitor/image_gen/html/plot_time.html
@@ -1511,4 +1511,15 @@
 
 <img id="chartImg" />
 
-</BODY></HTML>
+</BODY>
+
+<footer>
+    <P style="background-color: lightblue;"><u><b>Disclaimer:</b></u> These are not official
+              NWS products and should not to be relied upon for operational purposes. This web
+              site is not subject to 24/7 support, and thus may be unavailable during system
+              outages. For more information please see this
+              <a href="https://www.weather.gov/disclaimer.php">Disclaimer</a>
+    </P>
+</footer>
+
+</HTML>


### PR DESCRIPTION
In the process of working on #128 I discovered the RadMon html template files, which are used to construct websites, did not have the required disclaimer indicating the site is non-operational. 

This is a simple cut and paste fix but it's important since the RadMon websites we are available to the public, so expectations should be set appropriately.


Closes #150.