### PR TITLE
Correct calling sequence to rgn_find_cyc.py

### DIFF
--- a/src/Radiance_Monitor/data_extract/ush/RadMon_DE_rgn.sh
+++ b/src/Radiance_Monitor/data_extract/ush/RadMon_DE_rgn.sh
@@ -213,7 +213,7 @@ jobname=${jobname:-RadMon_DE_${RADMON_SUFFIX}}
 
 if [[ -z "${pdate}" ]]; then
    echo "getting pdate from TANKVERF"
-   ldate=`${MON_USH}/rgn_find_cycle.pl --cyc 1 --dir ${TANKverf}`
+   ldate=`${MON_USH}/rgn_find_cycle.pl --dir ${TANKverf} --mon radmon`
 
    if [[ ${#ldate} -ne 10 ]]; then
       echo "ERROR:  Unable to locate any previous cycle's data files"


### PR DESCRIPTION
In `RadMon_DE_rgn.sh` correct the calling sequence to `rgn_find_cyc.py`.  I had corrected this in the RadMon installation that I run with my crons but failed to get this into the development branch.  It's been running successfully with NAM data for at least 2 months, probably longer.


Closes #155 