### PR TITLE
Update hera.gnu module files to use current spack-stack

### DIFF
--- a/modulefiles/hera.gnu-run.lua
+++ b/modulefiles/hera.gnu-run.lua
@@ -1,10 +1,10 @@
 help([[
 ]])
 
-prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev-rocky8/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/scratch4/NCEPDEV/stmp/role.epic/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev-rocky8/install/modulefiles/Core")
 
 local stack_gnu_ver=os.getenv("stack_gnu_ver") or "9.2.0"
-local stack_openmpi_ver=os.getenv("stack_openmpi_ver") or "4.1.5"
+local stack_openmpi_ver=os.getenv("stack_openmpi_ver") or "4.1.6"
 local prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
 local grads_ver=os.getenv("grads_ver") or "2.2.3"
 local perl_ver=os.getenv("perl_ver") or "5.38.0"

--- a/modulefiles/hera.gnu.lua
+++ b/modulefiles/hera.gnu.lua
@@ -1,10 +1,10 @@
 help([[
 ]])
 
-prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev-rocky8/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/scratch4/NCEPDEV/stmp/role.epic/spack-stack/spack-stack-1.6.0/envs/gsi-addon-dev-rocky8/install/modulefiles/Core")
 
 local stack_gnu_ver=os.getenv("stack_gnu_ver") or "9.2.0"
-local stack_openmpi_ver=os.getenv("stack_openmpi_ver") or "4.1.5"
+local stack_openmpi_ver=os.getenv("stack_openmpi_ver") or "4.1.6"
 local cmake_ver=os.getenv("cmake_ver") or "3.23.1"
 
 load(pathJoin("stack-gcc", stack_gnu_ver))


### PR DESCRIPTION
Updated hera.gnu* module files to use current spack-stack on hera.

Confirmed both intel and gnu builds now work.

Closes #163 