### PR TITLE
Make GSI-Monitor working on CSPs with Rocky 8

### DIFF
--- a/noaacloud-run.intel.lua
+++ b/noaacloud-run.intel.lua
@@ -1,0 +1,20 @@
+help([[
+]])
+
+prepend_path("MODULEPATH", "/contrib/spack-stack-rocky8/spack-stack-1.6.0/envs/gsi-addon-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/apps/modules/modulefiles")
+
+local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.10.0"
+local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.10.0"
+
+load("gnu")
+load(pathJoin("stack-intel", stack_intel_ver))
+load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
+unload("gnu")
+
+local grads_ver=os.getenv("grads_ver") or "2.2.3"
+local prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
+
+load("common-run")
+
+whatis("Description: GSI Monitoring run-time environment on NOAA Cloud Intel compiler")

--- a/noaacloud.intel.lua
+++ b/noaacloud.intel.lua
@@ -1,0 +1,18 @@
+help([[
+]])
+
+prepend_path("MODULEPATH", "/contrib/spack-stack-rocky8/spack-stack-1.6.0/envs/gsi-addon-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/apps/modules/modulefiles")
+
+local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.10.0"
+local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.10.0"
+local cmake_ver=os.getenv("cmake_ver") or "3.23.1"
+
+load("gnu")
+load(pathJoin("stack-intel", stack_intel_ver))
+load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
+unload("gnu")
+
+load("common")
+
+whatis("Description: GSI Monitoring environment on NOAA Cloud with Intel Compilers")


### PR DESCRIPTION
As CSPs fully transferred to Rocky 8 compiler, GSI monitor has to switch to Rocky 8 on cloud if using GSI.
We only need to update:

1. noaacloud-run.intel.lua
2. noaacloud.intel.lua

See issue #170 