### PR TITLE
Fix ConMon image file clean up

### DIFF
--- a/src/Conventional_Monitor/image_gen/ush/rm_img_files.pl
+++ b/src/Conventional_Monitor/image_gen/ush/rm_img_files.pl
@@ -86,7 +86,7 @@ if( $#unique >= $nfl ) {
    foreach my $sdir ( @sdir_list ) {
       foreach my $del ( @del_list ) {
          my $rm_cmd = "find $dir/$sdir -type f -name '*$del*' -delete";
-         print "FIND: $rm_cmd\n";
+         print "RM: $rm_cmd\n";
          system( $rm_cmd ) == 0
             or die "system $rm_cmd failed: $?";
       }

--- a/src/Conventional_Monitor/image_gen/ush/rm_img_files.pl
+++ b/src/Conventional_Monitor/image_gen/ush/rm_img_files.pl
@@ -85,8 +85,8 @@ if( $#unique >= $nfl ) {
 
    foreach my $sdir ( @sdir_list ) {
       foreach my $del ( @del_list ) {
-         my $rm_cmd = "rm -f $dir/$sdir/*$del*";
-         print "RM:  $rm_cmd\n";
+         my $rm_cmd = "find $dir/$sdir -type f -name '*$del*' -delete";
+         print "FIND: $rm_cmd\n";
          system( $rm_cmd ) == 0
             or die "system $rm_cmd failed: $?";
       }

--- a/src/Conventional_Monitor/image_gen/ush/rm_img_files.pl
+++ b/src/Conventional_Monitor/image_gen/ush/rm_img_files.pl
@@ -86,7 +86,7 @@ if( $#unique >= $nfl ) {
    foreach my $sdir ( @sdir_list ) {
       foreach my $del ( @del_list ) {
          my $rm_cmd = "find $dir/$sdir -type f -name '*$del*' -delete";
-         print "RM: $rm_cmd\n";
+         print "RM:  $rm_cmd\n";
          system( $rm_cmd ) == 0
             or die "system $rm_cmd failed: $?";
       }


### PR DESCRIPTION
An unintended consequence of increasing the number of regions plotted in the ConMon (#169) is that the image file cleanup script began failing when trying to remove out of date time-series plots.  The issue is straightforward -- the `rm` command was receiving too many arguments (files).  The implemented solution is to use `find` instead.

This fix has been tested on wcoss2 with the last 3 plotted cycles.  All older files (> 5 cycles from current) have been removed and no errors have been reported in the logs.

Closes #173 