### PR TITLE
Update wcoss2 module files to use new hpc stack

### DIFF
--- a/modulefiles/wcoss2.intel-run.lua
+++ b/modulefiles/wcoss2.intel-run.lua
@@ -1,14 +1,18 @@
 help([[
 ]])
 
-local intel_ver=os.getenv("intel_ver") or "19.1.3.304"
+prepend_path("MODULEPATH", "/apps/test/hpc-stack/i-19.1.3.304__m-8.1.12__h-1.14.0__n-4.9.2__p-2.5.10__e-8.4.2/modulefiles/core")
+
+local hpc_intel_ver=os.getenv("hpc_intel_ver") or "19.1.3.304"
+
+--local intel_ver=os.getenv("intel_ver") or "19.1.3.304"
 local prod_util_ver=os.getenv("prod_util_ver") or "2.0.13"
 local prod_envir_ver=os.getenv("prod_envir_ver") or "2.0.6"
 
 local netcdf_ver=os.getenv("netcdf_ver") or "4.7.4"
 local wgrib2_ver=os.getenv("wgrib2_ver") or "2.0.8"
 
-load(pathJoin("intel", intel_ver))
+load(pathJoin("hpc-intel", hpc_intel_ver))
 load(pathJoin("prod_util", prod_util_ver))
 load(pathJoin("prod_envir", prod_envir_ver))
 

--- a/modulefiles/wcoss2.intel.lua
+++ b/modulefiles/wcoss2.intel.lua
@@ -1,10 +1,11 @@
 help([[
 ]])
 
-local PrgEnv_intel_ver=os.getenv("PrgEnv_intel_ver") or "8.1.0"
-local intel_ver=os.getenv("intel_ver") or "19.1.3.304"
+prepend_path("MODULEPATH", "/apps/test/hpc-stack/i-19.1.3.304__m-8.1.12__h-1.14.0__n-4.9.2__p-2.5.10__e-8.4.2/modulefiles/core")
+
+local hpc_intel_ver=os.getenv("hpc_intel_ver") or "19.1.3.304"
 local craype_ver=os.getenv("craype_ver") or "2.7.8"
-local cray_mpich_ver=os.getenv("cray_mpich_ver") or "8.1.7"
+local hpc_cray_mpich_ver=os.getenv("hpc_cray_mpich_ver") or "8.1.12"
 local cmake_ver= os.getenv("cmake_ver") or "3.20.2"
 
 local netcdf_ver=os.getenv("netcdf_ver") or "4.7.4"
@@ -12,10 +13,9 @@ local bacio_ver=os.getenv("bacio_ver") or "2.4.1"
 local w3emc_ver=os.getenv("w3emc_ver") or "2.9.2"
 local ncdiag_ver=os.getenv("ncdiag_ver") or "1.0.0"
 
-load(pathJoin("PrgEnv-intel", PrgEnv_intel_ver))
-load(pathJoin("intel", intel_ver))
+load(pathJoin("hpc-intel", hpc_intel_ver))
 load(pathJoin("craype", craype_ver))
-load(pathJoin("cray-mpich", cray_mpich_ver))
+load(pathJoin("hpc-cray-mpich", hpc_cray_mpich_ver))
 load(pathJoin("cmake", cmake_ver))
 
 load(pathJoin("netcdf", netcdf_ver))


### PR DESCRIPTION
@DavidHuber-NOAA  I had a moment to work on this and think I've gotten all the changes needed to move the GSI-monitor build/run to the new hpc stack.  Build works fine and the run module loads w/o error.


Closes #104 