### PR TITLE
Unload cray-libsci module on C6

### DIFF
--- a/modulefiles/gaeac6.intel-run.lua
+++ b/modulefiles/gaeac6.intel-run.lua
@@ -14,5 +14,6 @@ load(pathJoin("grads", grads_ver))
 load(pathJoin("prod_util", prod_util_ver))
 
 load("common-run")
+unload("cray-libsci")
 
 whatis("Description: GSI Monitoring run-time environment on GaeaC6.intel")

--- a/modulefiles/gaeac6.intel.lua
+++ b/modulefiles/gaeac6.intel.lua
@@ -12,5 +12,6 @@ load(pathJoin("stack-cray-mpich", stack_cray_mpich_ver))
 load(pathJoin("cmake", cmake_ver))
 
 load("common")
+unload("cray-libsci")
 
 whatis("Description: GSI Monitoring environment on GaeaC6 with Intel Compilers")


### PR DESCRIPTION
After maintenance on 6/16/2025, the cray-libsci module is being loaded, but this is causing issues with multiple builds, including gsi-monitor.  Unloading the module allows the gsi-monitor to build.

Refs noaa-emc/global-workflow#3820