### PR TITLE
Update to spack-stack 1.9.2

### DIFF
--- a/modulefiles/gaeac6.intel-run.lua
+++ b/modulefiles/gaeac6.intel-run.lua
@@ -1,7 +1,7 @@
 help([[
 ]])
 
-prepend_path("MODULEPATH", "/ncrc/proj/epic/spack-stack/c6/spack-stack-1.9.1/envs/ue-intel-2023.2.0/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/ncrc/proj/epic/spack-stack/c6/spack-stack-1.9.2/envs/ue-intel-2023.2.0/install/modulefiles/Core")
 
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2023.2.0"
 local stack_cray_mpich_ver=os.getenv("stack_cray_mpich_ver") or "8.1.30"

--- a/modulefiles/gaeac6.intel.lua
+++ b/modulefiles/gaeac6.intel.lua
@@ -1,7 +1,7 @@
 help([[
 ]])
 
-prepend_path("MODULEPATH", "/ncrc/proj/epic/spack-stack/c6/spack-stack-1.9.1/envs/ue-intel-2023.2.0/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/ncrc/proj/epic/spack-stack/c6/spack-stack-1.9.2/envs/ue-intel-2023.2.0/install/modulefiles/Core")
 
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2023.2.0"
 local stack_cray_mpich_ver=os.getenv("stack_cray_mpich_ver") or "8.1.30"

--- a/modulefiles/hera.intel-run.lua
+++ b/modulefiles/hera.intel-run.lua
@@ -1,7 +1,7 @@
 help([[
 ]])
 
-prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.9.1/envs/ue-oneapi-2024.2.1/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.2.1/install/modulefiles/Core")
 
 local stack_oneapi_ver=os.getenv("stack_oneapi_ver") or "2024.2.1"
 local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.13"

--- a/modulefiles/hera.intel.lua
+++ b/modulefiles/hera.intel.lua
@@ -1,7 +1,7 @@
 help([[
 ]])
 
-prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.9.1/envs/ue-oneapi-2024.2.1/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.2.1/install/modulefiles/Core")
 
 local stack_oneapi_ver=os.getenv("stack_oneapi_ver") or "2024.2.1"
 local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.13"

--- a/modulefiles/hercules.intel-run.lua
+++ b/modulefiles/hercules.intel-run.lua
@@ -2,7 +2,7 @@ help([[
 ]])
 
 -- Spack Stack installation specs
-prepend_path("MODULEPATH", "/apps/contrib/spack-stack/spack-stack-1.9.1/envs/ue-oneapi-2024.1.0/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/apps/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.1.0/install/modulefiles/Core")
 
 local stack_oneapi_ver=os.getenv("stack_oneapi_ver") or "2024.2.1"
 local stack_intel_oneapi_mpi_ver=os.getenv("stack_intel_oneapi_mpi_ver") or "2021.13"

--- a/modulefiles/hercules.intel.lua
+++ b/modulefiles/hercules.intel.lua
@@ -2,7 +2,7 @@ help([[
 ]])
 
 -- Spack Stack installation specs
-prepend_path("MODULEPATH", "/apps/contrib/spack-stack/spack-stack-1.9.1/envs/ue-oneapi-2024.1.0/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/apps/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.1.0/install/modulefiles/Core")
 
 local stack_oneapi_ver=os.getenv("stack_oneapi_ver") or "2024.2.1"
 local stack_intel_oneapi_mpi=os.getenv("stack_intel_oneapi_mpi") or "2021.13"

--- a/modulefiles/orion.intel-run.lua
+++ b/modulefiles/orion.intel-run.lua
@@ -2,7 +2,7 @@ help([[
 ]])
 
 -- Spack Stack installation specs
-prepend_path("MODULEPATH", "/apps/contrib/spack-stack/spack-stack-1.9.1/envs/ue-oneapi-2024.1.0/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/apps/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.1.0/install/modulefiles/Core")
 
 local stack_oneapi_ver=os.getenv("stack_oneapi_ver") or "2024.2.1"
 local stack_intel_oneapi_mpi_ver=os.getenv("stack_intel_oneapi_mpi_ver") or "2021.13"

--- a/modulefiles/orion.intel.lua
+++ b/modulefiles/orion.intel.lua
@@ -2,7 +2,7 @@ help([[
 ]])
 
 -- Spack Stack installation specs
-prepend_path("MODULEPATH", "/apps/contrib/spack-stack/spack-stack-1.9.1/envs/ue-oneapi-2024.1.0/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/apps/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.1.0/install/modulefiles/Core")
 
 local stack_oneapi_ver=os.getenv("stack_oneapi_ver") or "2024.2.1"
 local stack_intel_oneapi_mpi=os.getenv("stack_intel_oneapi_mpi") or "2021.13"

--- a/modulefiles/ursa.intel-run.lua
+++ b/modulefiles/ursa.intel-run.lua
@@ -2,7 +2,7 @@ help([[
 ]])
 
 -- Spack Stack installation specs
-prepend_path("MODULEPATH", "/apps/contrib/spack-stack/spack-stack-1.9.1/envs/ue-oneapi-2024.2.1/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/apps/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.2.1/install/modulefiles/Core")
 
 local stack_oneapi_ver=os.getenv("stack_oneapi_ver") or "2024.2.1"
 local stack_intel_oneapi_mpi_ver=os.getenv("stack_intel_oneapi_mpi_ver") or "2021.13"

--- a/modulefiles/ursa.intel.lua
+++ b/modulefiles/ursa.intel.lua
@@ -2,7 +2,7 @@ help([[
 ]])
 
 -- Spack Stack installation specs
-prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.9.1/envs/ue-oneapi-2024.2.1/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.2.1/install/modulefiles/Core")
 
 local stack_oneapi_ver=os.getenv("stack_oneapi_ver") or "2024.2.1"
 local stack_intel_oneapi_mpi=os.getenv("stack_intel_oneapi_mpi") or "2021.13"


### PR DESCRIPTION
This updates the monitor to spack-stack 1.9.2.  There are no changes to the library versions used by the monitor, so it is just a path update.