### PR TITLE
Update cloud module files

### DIFF
--- a/modulefiles/noaacloud-run.intel.lua
+++ b/modulefiles/noaacloud-run.intel.lua
@@ -1,23 +1,19 @@
 help([[
 ]])
 
-prepend_path("MODULEPATH", "/contrib/spack-stack-rocky8/spack-stack-1.6.0/envs/gsi-addon-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/contrib/spack-stack-rocky8/spack-stack-1.9.1/envs/ue-oneapi-2024.2.1/install/modulefiles/Core")
 prepend_path("MODULEPATH", "/apps/modules/modulefiles")
 
 local gcc_ver=os.getenv("gcc_ver") or "13.2.0"
-local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.10.0"
-local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.10.0"
-
-load(pathJoin("gnu", gcc_ver))
-load(pathJoin("stack-intel", stack_intel_ver))
-load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
-
+local stack_oneapi_ver=os.getenv("stack_oneapi_ver") or "2024.2.1"
+local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.13"
 local grads_ver=os.getenv("grads_ver") or "2.2.3"
 local prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"
 
+load(pathJoin("stack-oneapi", stack_oneapi_ver))
+load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
 load(pathJoin("grads", grads_ver))
 load(pathJoin("prod_util", prod_util_ver))
-
 
 load("common-run")
 

--- a/modulefiles/noaacloud-run.intel.lua
+++ b/modulefiles/noaacloud-run.intel.lua
@@ -1,7 +1,7 @@
 help([[
 ]])
 
-prepend_path("MODULEPATH", "/contrib/spack-stack-rocky8/spack-stack-1.9.1/envs/ue-oneapi-2024.2.1/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/contrib/spack-stack-rocky8/spack-stack-1.9.2/envs/ue-oneapi-2024.2.1/install/modulefiles/Core")
 prepend_path("MODULEPATH", "/apps/modules/modulefiles")
 
 local gcc_ver=os.getenv("gcc_ver") or "13.2.0"

--- a/modulefiles/noaacloud-run.intel.lua
+++ b/modulefiles/noaacloud-run.intel.lua
@@ -4,13 +4,13 @@ help([[
 prepend_path("MODULEPATH", "/contrib/spack-stack-rocky8/spack-stack-1.6.0/envs/gsi-addon-env/install/modulefiles/Core")
 prepend_path("MODULEPATH", "/apps/modules/modulefiles")
 
+local gcc_ver=os.getenv("gcc_ver") or "13.2.0"
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.10.0"
 local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.10.0"
 
-load("gnu")
+load(pathJoin("gnu", gcc_ver))
 load(pathJoin("stack-intel", stack_intel_ver))
 load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
-unload("gnu")
 
 local grads_ver=os.getenv("grads_ver") or "2.2.3"
 local prod_util_ver=os.getenv("prod_util_ver") or "2.1.1"

--- a/modulefiles/noaacloud.intel.lua
+++ b/modulefiles/noaacloud.intel.lua
@@ -4,14 +4,14 @@ help([[
 prepend_path("MODULEPATH", "/contrib/spack-stack-rocky8/spack-stack-1.6.0/envs/gsi-addon-env/install/modulefiles/Core")
 prepend_path("MODULEPATH", "/apps/modules/modulefiles")
 
+local gcc_ver=os.getenv("gcc_ver") or "13.2.0"
 local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.10.0"
 local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.10.0"
 local cmake_ver=os.getenv("cmake_ver") or "3.23.1"
 
-load("gnu")
+load(pathJoin("gnu", gcc_ver))
 load(pathJoin("stack-intel", stack_intel_ver))
 load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
-unload("gnu")
 load(pathJoin("cmake", cmake_ver))
 
 load("common")

--- a/modulefiles/noaacloud.intel.lua
+++ b/modulefiles/noaacloud.intel.lua
@@ -1,7 +1,7 @@
 help([[
 ]])
 
-prepend_path("MODULEPATH", "/contrib/spack-stack-rocky8/spack-stack-1.9.1/envs/ue-oneapi-2024.2.1/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/contrib/spack-stack-rocky8/spack-stack-1.9.2/envs/ue-oneapi-2024.2.1/install/modulefiles/Core")
 prepend_path("MODULEPATH", "/apps/modules/modulefiles")
 
 local gcc_ver=os.getenv("gcc_ver") or "13.2.0"

--- a/modulefiles/noaacloud.intel.lua
+++ b/modulefiles/noaacloud.intel.lua
@@ -1,18 +1,16 @@
 help([[
 ]])
 
-prepend_path("MODULEPATH", "/contrib/spack-stack-rocky8/spack-stack-1.6.0/envs/gsi-addon-env/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/contrib/spack-stack-rocky8/spack-stack-1.9.1/envs/ue-oneapi-2024.2.1/install/modulefiles/Core")
 prepend_path("MODULEPATH", "/apps/modules/modulefiles")
 
 local gcc_ver=os.getenv("gcc_ver") or "13.2.0"
-local stack_intel_ver=os.getenv("stack_intel_ver") or "2021.10.0"
-local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.10.0"
-local cmake_ver=os.getenv("cmake_ver") or "3.23.1"
+local stack_oneapi_ver=os.getenv("stack_oneapi_ver") or "2024.2.1"
+local stack_impi_ver=os.getenv("stack_impi_ver") or "2021.13"
 
 load(pathJoin("gnu", gcc_ver))
-load(pathJoin("stack-intel", stack_intel_ver))
+load(pathJoin("stack-oneapi", stack_oneapi_ver))
 load(pathJoin("stack-intel-oneapi-mpi", stack_impi_ver))
-load(pathJoin("cmake", cmake_ver))
 
 load("common")
 


### PR DESCRIPTION
This PR updates the cloud build and run environments to work with the legacy and latest versions of the NOAA RDHPCS `/apps` stacks by specifying the GCC versions and maintaining the GNU stack. The cloud environments were also outdated by recent updates to spack-stack 1.9.1, so this PR also updates the cloud to spack-stack 1.9.1.  Spack-stack 1.9.2 is not yet available on the cloud, so the update to 1.9.2 will be addressed in a future PR. 

I tested on a PW AWS cluster with the latest RDHPCS `/apps` snapshot mounted. I tested the build environment by running the `ush/build.sh` script. I tested the run environment by loading the `noaacloud-run.intel` module without errors and checking `module avail` for correctly loaded modules.

Resolves #189 