### PR TITLE
Update WCOSS2 modulefiles

### DIFF
--- a/modulefiles/wcoss2.intel-run.lua
+++ b/modulefiles/wcoss2.intel-run.lua
@@ -2,17 +2,25 @@ help([[
 ]])
 
 local intel_ver=os.getenv("intel_ver") or "19.1.3.304"
+local craype_ver=os.getenv("craype_ver") or "2.7.8"
+local cray_mpich_ver=os.getenv("cray_mpich_ver") or "8.1.7"
 local prod_util_ver=os.getenv("prod_util_ver") or "2.0.13"
 local prod_envir_ver=os.getenv("prod_envir_ver") or "2.0.6"
 
-local netcdf_ver=os.getenv("netcdf_ver") or "4.7.4"
+local hdf5_ver=os.getenv("hdf5_ver") or "1.14.0"
+local pnetcdf_ver=os.getenv("pnetcdf_ver") or "1.12.2"
+local netcdf_ver=os.getenv("netcdf_ver") or "4.9.2"
 local wgrib2_ver=os.getenv("wgrib2_ver") or "2.0.8"
 
 load(pathJoin("intel", intel_ver))
+load(pathJoin("craype", craype_ver))
+load(pathJoin("cray-mpich", cray_mpich_ver))
 load(pathJoin("prod_util", prod_util_ver))
 load(pathJoin("prod_envir", prod_envir_ver))
 
-load(pathJoin("netcdf", netcdf_ver))
+load(pathJoin("hdf5-D", hdf5_ver))
+load(pathJoin("pnetcdf-D", pnetcdf_ver))
+load(pathJoin("netcdf-D", netcdf_ver))
 load(pathJoin("wgrib2", wgrib2_ver))
 
 prepend_path("MODULEPATH", "/apps/test/lmodules/core/")

--- a/modulefiles/wcoss2.intel.lua
+++ b/modulefiles/wcoss2.intel.lua
@@ -7,10 +7,12 @@ local craype_ver=os.getenv("craype_ver") or "2.7.8"
 local cray_mpich_ver=os.getenv("cray_mpich_ver") or "8.1.7"
 local cmake_ver= os.getenv("cmake_ver") or "3.20.2"
 
-local netcdf_ver=os.getenv("netcdf_ver") or "4.7.4"
+local hdf5_ver=os.getenv("hdf5_ver") or "1.14.0"
+local pnetcdf_ver=os.getenv("netcdf_ver") or "1.12.2"
+local netcdf_ver=os.getenv("netcdf_ver") or "4.9.2"
 local bacio_ver=os.getenv("bacio_ver") or "2.4.1"
-local w3emc_ver=os.getenv("w3emc_ver") or "2.9.2"
-local ncdiag_ver=os.getenv("ncdiag_ver") or "1.0.0"
+local w3emc_ver=os.getenv("w3emc_ver") or "2.12.0"
+local ncdiag_ver=os.getenv("ncdiag_ver") or "1.1.2"
 
 load(pathJoin("PrgEnv-intel", PrgEnv_intel_ver))
 load(pathJoin("intel", intel_ver))
@@ -18,9 +20,11 @@ load(pathJoin("craype", craype_ver))
 load(pathJoin("cray-mpich", cray_mpich_ver))
 load(pathJoin("cmake", cmake_ver))
 
-load(pathJoin("netcdf", netcdf_ver))
+load(pathJoin("hdf5-D", hdf5_ver))
+load(pathJoin("pnetcdf-D", pnetcdf_ver))
+load(pathJoin("netcdf-D", netcdf_ver))
 load(pathJoin("bacio", bacio_ver))
 load(pathJoin("w3emc", w3emc_ver))
-load(pathJoin("ncdiag", ncdiag_ver))
+load(pathJoin("ncdiag-A", ncdiag_ver))
 
 whatis("Description: GSI Monitoring environment on WCOSS2")


### PR DESCRIPTION
This updates the WCOSS2 modules to use netcdf 4.9.2.  Note that the netcdf libraries in version 4.9.2 are dynamic, meaning that the module must be loaded at both compile and run times and libraries that the netcdf library was built with (hdf5 and pnetcdf) must also have their modules loaded.