### PR TITLE
Fix radmon_angle.x error when run in debug mode Ref #197

### DIFF
--- a/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radang.fd/angle_bias.f90
+++ b/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radang.fd/angle_bias.f90
@@ -280,6 +280,7 @@ program angle
 
 ! Loop to read entries in diagnostic file
   iflag = 0
+  rread = 0
   loopd:  do while (iflag == 0)
 
 


### PR DESCRIPTION
When built in "debug" mode the radmon_angle.x executable fails with an error code of 134.  It runs without error when built in "release" mode.  

This problem was reported in #197 and I was able to reproduce this problem locally.  The problem is quite simple -- an uninitialized counter is being used.  Apparently in "release" builds this defaults to 0, but "debug" properly objects and the result is a fatal error.  Initializing the variable fixes the problem in "debug" builds.


Fixes #197.