### PR TITLE
Clear debug mode compile warnings in OznMon

### DIFF
--- a/src/Ozone_Monitor/data_xtrct/sorc/make_base.fd/make_base.f90
+++ b/src/Ozone_Monitor/data_xtrct/sorc/make_base.fd/make_base.f90
@@ -1,5 +1,6 @@
 program oznmon_make_base
   implicit none
+  external :: errexit
 
 !  Note that nregion is 6, but for error checking purposes we only 
 !    need to consider region 1, which is "global". 
@@ -11,8 +12,7 @@ program oznmon_make_base
 
   character(20) satname
 
-  real,allocatable,dimension(:,:,:):: count,error,use,penalty
-  real,allocatable,dimension(:,:,:):: omg_cor
+  real,allocatable,dimension(:,:,:):: count,penalty
 
   character(40) cycle_file, data_file, level_file, out_file
 
@@ -26,7 +26,7 @@ program oznmon_make_base
   real,allocatable,dimension(:,:):: min_count, max_count
   real,allocatable,dimension(:,:):: min_penalty, max_penalty
 
-  real total_sdv, avg_sdv, diff_count, diff_total, diff_pen, temp
+  real diff_count, diff_total, diff_pen
 
   character(10) cycle
 

--- a/src/Ozone_Monitor/nwprod/oznmon_shared/sorc/oznmon_horiz.fd/create_ctl_horiz.f90
+++ b/src/Ozone_Monitor/nwprod/oznmon_shared/sorc/oznmon_horiz.fd/create_ctl_horiz.f90
@@ -3,6 +3,8 @@ subroutine create_ctl_horiz(ntype,ptype,var_list,n_levs,iyy,imm,idd,ihh,idhh,&
      error,iuse,satype,dplat)
 
   implicit none
+  external :: w3movdat
+  external :: errexit
 
   integer ntype
 
@@ -15,7 +17,6 @@ subroutine create_ctl_horiz(ntype,ptype,var_list,n_levs,iyy,imm,idd,ihh,idhh,&
   character(40) ctl_file,grad_file
   character(80) string
 
-  integer idsat
   integer,dimension(n_levs):: iuse
   integer,dimension(8):: ida,jda
   real,dimension(5):: fha

--- a/src/Ozone_Monitor/nwprod/oznmon_shared/sorc/oznmon_horiz.fd/horiz.f90
+++ b/src/Ozone_Monitor/nwprod/oznmon_shared/sorc/oznmon_horiz.fd/horiz.f90
@@ -2,6 +2,9 @@ program horiz
   use oznmon_read_diag
 
   implicit none
+  external :: create_ctl_horiz
+  external :: errexit
+
   integer ntype, mls2_levs,mls3_levs
   parameter (ntype=4)
   parameter (mls2_levs=37)
@@ -14,16 +17,16 @@ program horiz
   character(6),dimension(ntype):: anl_vars
   character(8) stid
   character(20) satname,stringd,satsis
-  character(10) dum,satype,dplat
+  character(10) satype,dplat
   character(40) string,grad_file,ctl_file
   character(500) diag_oz
 
   integer luname,lungrd,lunctl,lndiag,isave
   integer iyy,imm,idd,ihh,idhh,incr,iread,irite,iflag
-  integer n_levs,j,nlev,nflag,i,nlevs,nobs,iobs,m_levs,k,lev_nobs
+  integer n_levs,j,nlev,nflag,i,nobs,iobs,m_levs,k,lev_nobs
   integer,allocatable,dimension(:):: iuse
 
-  real weight,rlat,rlon,rtim,rmiss,obs,ges,obsges,sza,fovn,toqf
+  real rlat,rlon,rtim,rmiss,obs,ges,obsges
   real,allocatable,dimension(:):: error,dlat,dlon
   real,allocatable,dimension(:):: prs_nlev
   real,allocatable,dimension(:,:):: var,var1

--- a/src/Ozone_Monitor/nwprod/oznmon_shared/sorc/oznmon_horiz.fd/oznmon_read_diag.f90
+++ b/src/Ozone_Monitor/nwprod/oznmon_shared/sorc/oznmon_horiz.fd/oznmon_read_diag.f90
@@ -285,7 +285,7 @@ module oznmon_read_diag
     istatus = 0
  
     if ( netcdf ) then
-       call read_ozndiag_header_nc( ftin, header_fix, header_nlev, new_hdr, istatus )
+       call read_ozndiag_header_nc( ftin, header_fix, header_nlev, istatus )
     else
        call read_ozndiag_header_bin( ftin, header_fix, header_nlev, new_hdr, istatus )
     endif
@@ -311,14 +311,13 @@ module oznmon_read_diag
   !------------------------------------------------------------
   !  subroutine read_ozndiag_header_nc
   !------------------------------------------------------------
-  subroutine read_ozndiag_header_nc( ftin, header_fix, header_nlev, new_hdr, istatus )
+  subroutine read_ozndiag_header_nc( ftin, header_fix, header_nlev, istatus )
 
     !--- interface
 
     integer                    ,intent(in)  :: ftin
     type(diag_header_fix_list ),intent(out) :: header_fix
     type(diag_header_nlev_list),pointer     :: header_nlev(:)
-    logical                                 :: new_hdr
     integer(i_kind),intent(out)             :: istatus
 
     !--- variables
@@ -327,11 +326,10 @@ module oznmon_read_diag
 
     character(len=10):: sat,obstype
     character(len=20):: isis
-    integer(i_kind):: jiter,nlevs
-    integer(i_kind),dimension(:),allocatable :: iouse
+    integer(i_kind):: nlevs
     real(r_double),dimension(:),allocatable  :: pobs,gross,tnoise
    
-    integer(i_kind)                          :: nsdim,k,idate,idx
+    integer(i_kind)                          :: k,idate,idx
     integer(i_kind),dimension(:),allocatable :: iuse_flag
 
  
@@ -467,7 +465,7 @@ module oznmon_read_diag
     !--- variables
     
     integer,save :: nlevs_last = -1
-    integer :: ilev,k,ioff0
+    integer :: k,ioff0
     character(len=10):: id,obstype
     character(len=20):: isis
     integer(i_kind):: jiter,nlevs,ianldate,iint,ireal,iextra
@@ -570,7 +568,7 @@ module oznmon_read_diag
    
 
     if ( netcdf ) then
-       call read_ozndiag_data_nc( ftin, header_fix, data_fix, data_nlev, data_extra, ntobs, iflag )
+       call read_ozndiag_data_nc( ftin, header_fix, data_fix, data_nlev, ntobs, iflag )
     else
        call read_ozndiag_data_bin( ftin, header_fix, data_fix, data_nlev, data_extra, ntobs, iflag )
     end if 
@@ -582,7 +580,7 @@ module oznmon_read_diag
   !------------------------------------------------  
   !  subroutine read_ozndiag_data_nc
   !------------------------------------------------  
-  subroutine read_ozndiag_data_nc( ftin, header_fix, data_fix, data_nlev, data_extra, ntobs, iflag )
+  subroutine read_ozndiag_data_nc( ftin, header_fix, data_fix, data_nlev, ntobs, iflag )
 
     !--- interface
 
@@ -596,12 +594,10 @@ module oznmon_read_diag
     !
     type(diag_data_fix_list),   pointer     :: data_fix(:)
     type(diag_data_nlev_list)  ,pointer     :: data_nlev(:,:)
-    type(diag_data_extra_list) ,pointer     :: data_extra(:,:)
 
     integer                    ,intent(out) :: iflag
     integer(i_kind)            ,intent(out) :: ntobs
     integer(i_kind)                         :: id,ii,jj,cur_idx
-    integer(i_kind),allocatable             :: Use_Flag(:)
     integer(i_kind)                         :: nlevs             ! number of levels
     integer(i_kind)                         :: nrecords          ! number of file records, which 
                                                                  ! is number of levels * number of obs
@@ -618,8 +614,6 @@ module oznmon_read_diag
     real(r_single),allocatable              :: fovn(:)           ! scan position (fielf of view)
     real(r_single),allocatable              :: toqf(:)           ! row anomaly index
    
-    logical                                 :: test
-
     cur_idx = ncdiag_open_id( nopen_ncdiag )
   
     !----------------------------------------------------------
@@ -830,7 +824,7 @@ module oznmon_read_diag
     !--- variables
     integer,save :: nlevs_last = -1
     integer,save :: iextra_last = -1
-    integer :: iev,iobs,i,j
+    integer :: i,j
     real(r_single),allocatable,dimension(:,:)  :: tmp_fix
     real(r_single),allocatable,dimension(:,:,:):: tmp_nlev
     real(r_single),allocatable,dimension(:,:)  :: tmp_extra

--- a/src/Ozone_Monitor/nwprod/oznmon_shared/sorc/oznmon_time.fd/create_ctl_time.f90
+++ b/src/Ozone_Monitor/nwprod/oznmon_shared/sorc/oznmon_time.fd/create_ctl_time.f90
@@ -3,6 +3,7 @@ subroutine create_ctl_oz(ntype,ptype,var_list,n_levs,iyy,imm,idd,ihh,idhh,&
      region,rlonmin,rlonmax,rlatmin,rlatmax,nu_nlev,use,error)
 
   implicit none
+  external :: w3movdat
 
   integer ntype
 
@@ -19,8 +20,8 @@ subroutine create_ctl_oz(ntype,ptype,var_list,n_levs,iyy,imm,idd,ihh,idhh,&
   character(40),dimension(nregion):: region
   character(80),dimension(nregion):: stringr
 
-  integer idsat,nregion,iuse
-  integer lunctl,iyy,imm,idd,ihh,j,i,n_levs,idhh,incr
+  integer nregion,iuse
+  integer lunctl,iyy,imm,idd,ihh,i,n_levs,idhh,incr
   integer iyy2,imm2,idd2,ihh2,ntime
   integer,dimension(8):: ida,jda
   real,dimension(n_levs):: nu_nlev

--- a/src/Ozone_Monitor/nwprod/oznmon_shared/sorc/oznmon_time.fd/oznmon_read_diag.f90
+++ b/src/Ozone_Monitor/nwprod/oznmon_shared/sorc/oznmon_time.fd/oznmon_read_diag.f90
@@ -285,7 +285,7 @@ module oznmon_read_diag
     istatus = 0
  
     if ( netcdf ) then
-       call read_ozndiag_header_nc( ftin, header_fix, header_nlev, new_hdr, istatus )
+       call read_ozndiag_header_nc( ftin, header_fix, header_nlev, istatus )
     else
        call read_ozndiag_header_bin( ftin, header_fix, header_nlev, new_hdr, istatus )
     endif
@@ -311,14 +311,13 @@ module oznmon_read_diag
   !------------------------------------------------------------
   !  subroutine read_ozndiag_header_nc
   !------------------------------------------------------------
-  subroutine read_ozndiag_header_nc( ftin, header_fix, header_nlev, new_hdr, istatus )
+  subroutine read_ozndiag_header_nc( ftin, header_fix, header_nlev, istatus )
 
     !--- interface
 
     integer                    ,intent(in)  :: ftin
     type(diag_header_fix_list ),intent(out) :: header_fix
     type(diag_header_nlev_list),pointer     :: header_nlev(:)
-    logical                                 :: new_hdr
     integer(i_kind),intent(out)             :: istatus
 
     !--- variables
@@ -327,11 +326,10 @@ module oznmon_read_diag
 
     character(len=10):: sat,obstype
     character(len=20):: isis
-    integer(i_kind):: jiter,nlevs
-    integer(i_kind),dimension(:),allocatable :: iouse
+    integer(i_kind):: nlevs
     real(r_double),dimension(:),allocatable  :: pobs,gross,tnoise
    
-    integer(i_kind)                          :: nsdim,k,idate,idx
+    integer(i_kind)                          :: k,idate,idx
     integer(i_kind),dimension(:),allocatable :: iuse_flag
 
  
@@ -467,7 +465,7 @@ module oznmon_read_diag
     !--- variables
     
     integer,save :: nlevs_last = -1
-    integer :: ilev,k,ioff0
+    integer :: k,ioff0
     character(len=10):: id,obstype
     character(len=20):: isis
     integer(i_kind):: jiter,nlevs,ianldate,iint,ireal,iextra
@@ -570,7 +568,7 @@ module oznmon_read_diag
    
 
     if ( netcdf ) then
-       call read_ozndiag_data_nc( ftin, header_fix, data_fix, data_nlev, data_extra, ntobs, iflag )
+       call read_ozndiag_data_nc( ftin, header_fix, data_fix, data_nlev, ntobs, iflag )
     else
        call read_ozndiag_data_bin( ftin, header_fix, data_fix, data_nlev, data_extra, ntobs, iflag )
     end if 
@@ -582,7 +580,7 @@ module oznmon_read_diag
   !------------------------------------------------  
   !  subroutine read_ozndiag_data_nc
   !------------------------------------------------  
-  subroutine read_ozndiag_data_nc( ftin, header_fix, data_fix, data_nlev, data_extra, ntobs, iflag )
+  subroutine read_ozndiag_data_nc( ftin, header_fix, data_fix, data_nlev, ntobs, iflag )
 
     !--- interface
 
@@ -596,12 +594,10 @@ module oznmon_read_diag
     !
     type(diag_data_fix_list),   pointer     :: data_fix(:)
     type(diag_data_nlev_list)  ,pointer     :: data_nlev(:,:)
-    type(diag_data_extra_list) ,pointer     :: data_extra(:,:)
 
     integer                    ,intent(out) :: iflag
     integer(i_kind)            ,intent(out) :: ntobs
     integer(i_kind)                         :: id,ii,jj,cur_idx
-    integer(i_kind),allocatable             :: Use_Flag(:)
     integer(i_kind)                         :: nlevs             ! number of levels
     integer(i_kind)                         :: nrecords          ! number of file records, which 
                                                                  ! is number of levels * number of obs
@@ -618,8 +614,6 @@ module oznmon_read_diag
     real(r_single),allocatable              :: fovn(:)           ! scan position (fielf of view)
     real(r_single),allocatable              :: toqf(:)           ! row anomaly index
    
-    logical                                 :: test
-
     cur_idx = ncdiag_open_id( nopen_ncdiag )
   
     !----------------------------------------------------------
@@ -830,7 +824,7 @@ module oznmon_read_diag
     !--- variables
     integer,save :: nlevs_last = -1
     integer,save :: iextra_last = -1
-    integer :: iev,iobs,i,j
+    integer :: i,j
     real(r_single),allocatable,dimension(:,:)  :: tmp_fix
     real(r_single),allocatable,dimension(:,:,:):: tmp_nlev
     real(r_single),allocatable,dimension(:,:)  :: tmp_extra

--- a/src/Ozone_Monitor/nwprod/oznmon_shared/sorc/oznmon_time.fd/time.f90
+++ b/src/Ozone_Monitor/nwprod/oznmon_shared/sorc/oznmon_time.fd/time.f90
@@ -4,6 +4,9 @@ program main
    use kinds, only: i_kind
 
    implicit none
+   external :: errexit
+   external :: create_ctl_oz
+   external :: avgsdv
 
    integer ntype,mregion,mls2_levs,mls3_levs
    parameter (ntype=4,mregion=25,mls2_levs=37,mls3_levs=55)
@@ -12,21 +15,21 @@ program main
    character(10),dimension(ntype):: anl_vars
    character(10),dimension(ntype):: ges_vars
    character(20) satname,stringd,satsis
-   character(10) dum,obstype,dplat
+   character(10) obstype,dplat
    character(40) string,grad_file,ctl_file
    character(500) diag_oz
    character(40) bad_pen_file, bad_cnt_file
    character(40),dimension(mregion):: region
 
    integer luname,lungrd,lunctl,lndiag,nregion
-   integer lupen, lucnt, fiosp, fiosc
+   integer lupen, lucnt
    integer iyy,imm,idd,ihh,idhh,incr,iflag,ier,iret
-   integer n_levs,j,idsat,i,k,ii,nreg,nlevs,iobs,iread,nobs
+   integer n_levs,j,i,k,ii,nreg,iobs,iread,nobs
    integer,dimension(mregion):: jsub
    real,allocatable,dimension(:):: prs_nlev
 
    real pen,pbound,cbound
-   real weight,rlat,rlon,rmiss,obs,biascor,obsges,obsgesnbc,rterm
+   real rlat,rlon,rmiss
    real,dimension(2):: cor_omg
    real,dimension(mregion):: rlatmin,rlatmax,rlonmin,rlonmax
 

--- a/src/Ozone_Monitor/nwprod/oznmon_shared/sorc/oznmon_time.fd/valid.f90
+++ b/src/Ozone_Monitor/nwprod/oznmon_shared/sorc/oznmon_time.fd/valid.f90
@@ -60,9 +60,7 @@ module valid
       !--- variables
       character(20) fname
       character(40) test_satname
-      character(10) base_date
       character(20) dum1, dum2, dum3, dum4, dum5, dum6, dum7, dum8, dum9, dum10, dum11
-      character(20) dum
       integer fios
       integer level, region
 
@@ -231,9 +229,6 @@ module valid
       logical, intent( out )            :: valid
       real, intent( out )               :: bound
       integer, intent( out )		:: iret
-
-      !--- vars
-      real sdv2
 
 
       !--- initialize vars


### PR DESCRIPTION
This PR resolves compiler warnings for intel builds in "debug" mode for the OznMon components.  (Similar changes to the RadMon will be made in a separate PR.)

Two types of changes have been made:

- Removal of unused variables
- Declarations of external subroutines

These changes have been compiled using the intel compiler on wcoss2 in both 'debug' and 'release' modes as well as with this repository's CI tests using the gnu compiler.

Run-time testing of two OznMon data extraction executables has been conducted locally and the results are identical to those produced by the OznMon executables currently in the operational workflow.  


This PR resolves some, but not all of the issues in #118.  #118 should remain open after this PR is merged to develop.