### PR TITLE
Eliminate compiler warnings in RadMon and ConMon

### DIFF
--- a/src/Conventional_Monitor/image_gen/sorc/conmon_read_ps_IG.fd/histgram.f90
+++ b/src/Conventional_Monitor/image_gen/sorc/conmon_read_ps_IG.fd/histgram.f90
@@ -28,12 +28,11 @@ subroutine hist(mtype,rmodnbc,nchan,nxdata,ndata,rmin,rmax,rlev,fileo,ncount_vqc
    real sqr2
 
    real,dimension(nchan) :: rmean,rstd 
-   integer,dimension(nchan) :: nmean,nobs
+   integer,dimension(nchan) :: nobs
 
    real,dimension(nchan,400) :: ys
    real,dimension(400) :: xs
    real,dimension(401) :: xs2
-   real maxf
 
 
    sqr2=1.414213562

--- a/src/Conventional_Monitor/image_gen/sorc/conmon_read_ps_IG.fd/mainread_ps.f90
+++ b/src/Conventional_Monitor/image_gen/sorc/conmon_read_ps_IG.fd/mainread_ps.f90
@@ -8,11 +8,14 @@
 
    implicit none
 
+   external ::  convinfo_read
+   external ::  read_ps
+   external ::  read_ps_mor
+
    character*200 fname
    character*50 fileo, grads_info_file
-   character*15 mtype,dtype 
+   character*15 mtype
 
-!   real*4 tiny,huge,real
    integer nreal,insubtype
 
    integer(4):: ituse,ntumgrp,ntgroup,ntmiter
@@ -21,7 +24,7 @@
    real(4) :: ttwind,gtross,etrmax,etrmin,vtar_b,vtar_pg
    real rlev,rpress
 
-   real(4) :: rmiss,vqclmt,vqclmte
+   real(4) :: rmiss
 
    data rmiss/-999.0/ 
 
@@ -36,12 +39,10 @@
    ncount_vgc = 0
    ncount_gros = 0
 
-!   print *,mtype,nreal
 
    call convinfo_read(mtype,15,insubtype,ituse,ntumgrp,ntgroup,ntmiter,isubtype,&
                       ttwind,gtross,etrmax,etrmin,vtar_b,vtar_pg)
 
-!   print *,'ituse=',ituse,gtross
    write(6, *) 'ituse, gtross = ', ituse, gtross
 
    if (ituse >0) call read_ps(nreal,mtype,fname,fileo,gtross,rlev, grads_info_file ) 

--- a/src/Conventional_Monitor/image_gen/sorc/conmon_read_ps_IG.fd/read_ps.f90
+++ b/src/Conventional_Monitor/image_gen/sorc/conmon_read_ps_IG.fd/read_ps.f90
@@ -6,6 +6,9 @@ subroutine read_ps(nreal,mtype,fname,fileo,gtross,rlev, grads_info_file )
 
    implicit none
 
+   external ::  rm_dups
+   external ::  hist
+
    !-------------
    !  interface
    !
@@ -26,7 +29,7 @@ subroutine read_ps(nreal,mtype,fname,fileo,gtross,rlev, grads_info_file )
 
 
    real(4) :: tiny
-   integer nobs,ntotal,ngross,nreal_in,nlev
+   integer nobs,ntotal,nreal_in,nlev
    real(4) :: rmiss,vqclmt,vqclmte
 
    data rmiss / -999.0 / 

--- a/src/Conventional_Monitor/image_gen/sorc/conmon_read_ps_IG.fd/read_ps_mor.f90
+++ b/src/Conventional_Monitor/image_gen/sorc/conmon_read_ps_IG.fd/read_ps_mor.f90
@@ -6,6 +6,9 @@ subroutine read_ps_mor(nreal,mtype,fname,fileo,gtross,rlev, grads_info_file)
 
    implicit none
 
+   external ::  hist
+   external ::  rm_dups
+
    !-------------
    !  interface
    !
@@ -25,10 +28,10 @@ subroutine read_ps_mor(nreal,mtype,fname,fileo,gtross,rlev, grads_info_file)
    real(4),dimension(3,3000000) :: rpress
    integer,dimension(3) :: ncount,ncount_vqc,ncount_gros
 
-   integer nobs,ntotal,ngross,nreal_in,nlev
+   integer nobs,ntotal,nreal_in,nlev
    integer i,ilat,ilon,ipres,itime,iqc,iuse,imuse,iweight,ierr,ierr2,ierr3,iobs,iogs
-   integer nlat,nlon,npres,ntime,ndup
-   real(4) :: bmiss,vqclmt,vqclmte
+   integer ndup
+   real(4) :: bmiss
    real rgtross
 
    data bmiss/-999.0/ 

--- a/src/Conventional_Monitor/image_gen/sorc/conmon_read_pw_IG.fd/histgram.f90
+++ b/src/Conventional_Monitor/image_gen/sorc/conmon_read_pw_IG.fd/histgram.f90
@@ -13,12 +13,11 @@ subroutine hist(mtype,rmodnbc,nchan,nxdata,ndata,rmin,rmax,rlev,fileo,ncount_vqc
 
    real,dimension(nchan,nxdata) :: rmodnbc
    real,dimension(nchan) :: rmean,rstd 
-   integer,dimension(nchan) :: nmean,nobs,ndata,ncount_vqc,ncount_gros
+   integer,dimension(nchan) :: nobs,ndata,ncount_vqc,ncount_gros
 
    real,dimension(nchan,400) :: ys
    real,dimension(400) :: xs
    real,dimension(401) :: xs2
-   real maxf
 
    character*50 fileo
    character*15 mtype

--- a/src/Conventional_Monitor/image_gen/sorc/conmon_read_pw_IG.fd/mainread_pw.f90
+++ b/src/Conventional_Monitor/image_gen/sorc/conmon_read_pw_IG.fd/mainread_pw.f90
@@ -5,20 +5,23 @@
 
    implicit none
 
+   external ::  convinfo_read
+   external ::  read_pw
+   external ::  read_pw_mor
+
    character*200 fname
    character*50 fileo
-   character*15 mtype,dtype 
+   character*15 mtype
 
-   real*4 tiny,huge,real
    real rpress,rlev
 
-   integer nobs,nreal,ntotal,ngross,nreal_in,insubtype
+   integer nreal,insubtype
    integer isubtype,ncount_gros,ncount_vgc,ncount
 
-   integer(4):: ittype,ituse,ntumgrp,ntgroup,ntmiter,iflag
+   integer(4):: ituse,ntumgrp,ntgroup,ntmiter
    real(4) :: ttwind,gtross,etrmax,etrmin,vtar_b,vtar_pg
 
-   real(4) :: rmiss,vqclmt,vqclmte
+   real(4) :: rmiss
 
    data rmiss/-999.0/ 
 

--- a/src/Conventional_Monitor/image_gen/sorc/conmon_read_pw_IG.fd/read_pw.f90
+++ b/src/Conventional_Monitor/image_gen/sorc/conmon_read_pw_IG.fd/read_pw.f90
@@ -6,6 +6,9 @@ subroutine read_pw(nreal,mtype,fname,fileo,gtross,rlev)
 
    implicit none
 
+   external ::  rm_dups
+   external ::  hist
+
    real(4),allocatable,dimension(:,:)  :: rdiag
    real(4),dimension(3,3000000) :: rpress
    integer,dimension(3) :: ncount,ncount_vqc,ncount_gros
@@ -14,10 +17,10 @@ subroutine read_pw(nreal,mtype,fname,fileo,gtross,rlev)
    character*50 fileo
    character*15 mtype 
 
-   real(4) :: tiny,huge
+   real(4) :: tiny
    real rlev,rgtross,gtross,weight,ddf
 
-   integer nobs,nreal,ntotal,ngross,nreal_in,nlev
+   integer nobs,nreal,ntotal,nreal_in,nlev
    integer ilat,ilon,ipres,itime,iqc,iuse,imuse,iweight,ierr,ierr2,ierr3,iobs,iogs
    integer i,ndup,ioges,igos
 
@@ -25,7 +28,6 @@ subroutine read_pw(nreal,mtype,fname,fileo,gtross,rlev)
 
    data rmiss/-999.0/ 
    data tiny / 1.0e-6 /
-   data huge / 1.0e6 /
  
 
 !  print *,'nreal=',nreal

--- a/src/Conventional_Monitor/image_gen/sorc/conmon_read_pw_IG.fd/read_pw_mor.f90
+++ b/src/Conventional_Monitor/image_gen/sorc/conmon_read_pw_IG.fd/read_pw_mor.f90
@@ -6,6 +6,9 @@ subroutine read_pw_mor(nreal,mtype,fname,fileo,gtross,rlev)
 
    implicit none
 
+   external :: rm_dups
+   external :: hist
+
    real(4),allocatable,dimension(:,:)  :: rdiag
    real(4),dimension(3,3000000) :: rpress
    integer,dimension(3) :: ncount,ncount_vqc,ncount_gros
@@ -15,11 +18,11 @@ subroutine read_pw_mor(nreal,mtype,fname,fileo,gtross,rlev)
    character*15 mtype 
 
    real rgtross,gtross
-   integer nobs,nreal,ntotal,ngross,nreal_in,nlev
-   integer i,nlat,nlon,npres,ntime,ndup
+   integer nobs,nreal,ntotal,nreal_in,nlev
+   integer i,ndup
    integer ilat,ilon,ipres,itime,iqc,iuse,imuse,iweight,ierr,ierr2,ierr3,iobs,iogs
 
-   real(4) :: rmiss,vqclmt,vqclmte,rlev
+   real(4) :: rmiss,rlev
 
    data rmiss/-999.0/ 
 

--- a/src/Conventional_Monitor/image_gen/sorc/conmon_read_q_IG.fd/histgram.f90
+++ b/src/Conventional_Monitor/image_gen/sorc/conmon_read_q_IG.fd/histgram.f90
@@ -28,12 +28,11 @@ subroutine hist(mtype,rmodnbc,nchan,nxdata,ndata,rmin,rmax,rlev,fileo,ncount_vqc
    real sqr2
 
    real,dimension(nchan) :: rmean,rstd 
-   integer,dimension(nchan) :: nmean,nobs
+   integer,dimension(nchan) :: nobs
 
    real,dimension(nchan,400) :: ys
    real,dimension(400) :: xs
    real,dimension(401) :: xs2
-   real maxf
 
 
    sqr2=1.414213562

--- a/src/Conventional_Monitor/image_gen/sorc/conmon_read_q_IG.fd/mainread_q.f90
+++ b/src/Conventional_Monitor/image_gen/sorc/conmon_read_q_IG.fd/mainread_q.f90
@@ -5,18 +5,22 @@
 
    implicit none
 
+   external ::  convinfo_read
+   external ::  read_q
+   external ::  read_q_mor
+
    character*200 fname
    character*50 fileo, grads_info_file
-   character*15 dtype,mtype 
+   character*15 mtype 
   
    real rlev,rpress
 
-   integer nobs,nreal,ntotal,ngross,nreal_in,insubtype
+   integer nreal,insubtype
    integer isubtype,ncount,ncount_vgc,ncount_gros
 
-   integer(4):: ittype,ituse,ntumgrp,ntgroup,ntmiter,iflag
+   integer(4):: ituse,ntumgrp,ntgroup,ntmiter
    real(4) :: ttwind,gtross,etrmax,etrmin,vtar_b,vtar_pg
-   real(4) :: rmiss,vqclmt,vqclmte
+   real(4) :: rmiss
 
    data rmiss/-999.0/ 
 

--- a/src/Conventional_Monitor/image_gen/sorc/conmon_read_q_IG.fd/read_q.f90
+++ b/src/Conventional_Monitor/image_gen/sorc/conmon_read_q_IG.fd/read_q.f90
@@ -8,6 +8,9 @@ subroutine read_q( nreal, dtype, fname, fileo, gtross, rlev, grads_info_file )
 
    implicit none
 
+   external ::  hist
+   external ::  rm_dups
+
    integer, intent(in)                 :: nreal
    character*200, intent(in)           :: fname
    character*50, intent(in)            :: fileo
@@ -18,14 +21,13 @@ subroutine read_q( nreal, dtype, fname, fileo, gtross, rlev, grads_info_file )
    real(4),dimension(3,3000000)        :: rpress
    integer,dimension(3)                :: ncount,ncount_vqc,ncount_gros
 
-   real*4     tiny,real
+   real*4     tiny
    real       rlev,rgtross,gtross,weight,ddf
-   integer    nobs,ntotal,ngross,nreal_in,nlev
+   integer    nobs,ntotal,nreal_in,nlev
    integer    ilat,ilon,ipres,itime,iqc,iuse,imuse,iweight,ierr,ierr2,ierr3,iobs,iogs,iqsges
    integer    i,ndup,ioges,igos
 
    real(4)    :: rmiss,vqclmt,vqclmte
-   real(4)    :: rlat, rlon, rtim
 
    data rmiss / -999.0 / 
    data tiny / 1.0e-6 /

--- a/src/Conventional_Monitor/image_gen/sorc/conmon_read_q_IG.fd/read_q_mor.f90
+++ b/src/Conventional_Monitor/image_gen/sorc/conmon_read_q_IG.fd/read_q_mor.f90
@@ -7,6 +7,9 @@ subroutine read_q_mor( nreal, dtype, fname, fileo, gtross, rlev, grads_info_file
 
    implicit none
 
+   external ::  hist
+   external ::  rm_dups
+
    integer,       intent( in )         :: nreal
    character*15,  intent( in )         :: dtype 
    character*200, intent( in )         :: fname
@@ -21,10 +24,10 @@ subroutine read_q_mor( nreal, dtype, fname, fileo, gtross, rlev, grads_info_file
 
    real(4) :: rgtross
 
-   integer nobs,ntotal,ngross,nreal_in,nlev
-   integer i,nlat,nlon,npres,ntime,ndup
+   integer nobs,ntotal,nreal_in,nlev
+   integer i,ndup
    integer ilat,ilon,ipres,itime,iqc,iuse,imuse,iweight,ierr,ierr2,ierr3,iobs,iogs,iqsges
-   real(4) :: rmiss,vqclmt,vqclmte,rlev
+   real(4) :: rmiss,rlev
 
    data rmiss/-999.0/ 
 

--- a/src/Conventional_Monitor/image_gen/sorc/conmon_read_t_IG.fd/histgram.f90
+++ b/src/Conventional_Monitor/image_gen/sorc/conmon_read_t_IG.fd/histgram.f90
@@ -28,12 +28,11 @@ subroutine hist(mtype,rmodnbc,nchan,nxdata,ndata,rmin,rmax,rlev,fileo,ncount_vqc
    real sqr2
 
    real,dimension(nchan) :: rmean,rstd 
-   integer,dimension(nchan) :: nmean,nobs
+   integer,dimension(nchan) :: nobs
 
    real,dimension(nchan,400) :: ys
    real,dimension(400) :: xs
    real,dimension(401) :: xs2
-   real maxf
 
 
    sqr2=1.414213562

--- a/src/Conventional_Monitor/image_gen/sorc/conmon_read_t_IG.fd/mainread_t.f90
+++ b/src/Conventional_Monitor/image_gen/sorc/conmon_read_t_IG.fd/mainread_t.f90
@@ -5,17 +5,21 @@
 
    implicit none
 
+   external ::  convinfo_read
+   external ::  read_t
+   external ::  read_t_mor
+
    character*200 fname
    character*50 fileo, grads_info_file
    character*15 mtype 
 
-   integer nobs,nreal,ntotal,ngross,nreal_in,insubtype
+   integer nreal,insubtype
    integer isubtype,ncount_gros,ncount_vgc,ncount
-   integer(4):: ittype,ituse,ntumgrp,ntgroup,ntmiter,iflag
+   integer(4):: ituse,ntumgrp,ntgroup,ntmiter
    real rpress,rlev
    real(4) :: ttwind,gtross,etrmax,etrmin,vtar_b,vtar_pg
 
-   real(4) :: rmiss,vqclmt,vqclmte
+   real(4) :: rmiss
  
    data rmiss/-999.0/ 
 

--- a/src/Conventional_Monitor/image_gen/sorc/conmon_read_t_IG.fd/read_t.f90
+++ b/src/Conventional_Monitor/image_gen/sorc/conmon_read_t_IG.fd/read_t.f90
@@ -5,7 +5,10 @@
 subroutine read_t(nreal,dtype,fname,fileo,gtross,rlev, grads_info_file )
 
    implicit none
-  
+ 
+   external ::  rm_dups
+   external ::  hist
+
    !-------------
    !  interface 
    !
@@ -24,9 +27,9 @@ subroutine read_t(nreal,dtype,fname,fileo,gtross,rlev, grads_info_file )
    real(4),dimension(3,3000000) :: rpress
    integer,dimension(3) :: ncount,ncount_vqc,ncount_gros
 
-   real*4 tiny,real
-   integer nobs,ntotal,ngross,nreal_in,nlev
-   integer nint,igos,ioges,i,j,ndup
+   real*4 tiny
+   integer nobs,ntotal,nreal_in,nlev
+   integer nint,igos,ioges,i,ndup
    integer ilat,ilon,ipres,itime,iqc,iuse,imuse,iweight,ierr,ierr2,ierr3,iobs,iogs
    real rgtross,ddf,weight
 

--- a/src/Conventional_Monitor/image_gen/sorc/conmon_read_t_IG.fd/read_t_mor.f90
+++ b/src/Conventional_Monitor/image_gen/sorc/conmon_read_t_IG.fd/read_t_mor.f90
@@ -6,6 +6,8 @@ subroutine read_t_mor(nreal,dtype,fname,fileo,gtross,rlev, grads_info_file )
 
    implicit none
 
+   external ::  rm_dups
+   external ::  hist
 
    !-------------
    !  interface
@@ -25,11 +27,11 @@ subroutine read_t_mor(nreal,dtype,fname,fileo,gtross,rlev, grads_info_file )
    real(4),dimension(3,3000000) :: rpress
    integer,dimension(3) :: ncount,ncount_vqc,ncount_gros
 
-   integer nobs,ntotal,ngross,nreal_in,nlev
-   integer i,ndup,nlat,nlon,npres,ntime
+   integer nobs,ntotal,nreal_in,nlev
+   integer i,ndup
    integer ilat,ilon,ipres,itime,iqc,iuse,imuse,iweight,ierr,ierr2,ierr3,iobs,iogs
    real rgtross
-   real(4) :: rmiss,vqclmt,vqclmte
+   real(4) :: rmiss
 
    data rmiss/-999.0/ 
 

--- a/src/Conventional_Monitor/image_gen/sorc/conmon_read_uv_IG.fd/histgram.f90
+++ b/src/Conventional_Monitor/image_gen/sorc/conmon_read_uv_IG.fd/histgram.f90
@@ -28,12 +28,11 @@ subroutine hist( mtype, rmodnbc, nchan, nxdata, ndata, rmin, rmax, rlev, &
    real sqr2
 
    real,dimension(nchan) :: rmean,rstd 
-   integer,dimension(nchan) :: nmean,nobs
+   integer,dimension(nchan) :: nobs
 
    real,dimension(nchan,400) :: ys
    real,dimension(400) :: xs
    real,dimension(401) :: xs2
-   real maxf
 
 
    sqr2=1.414213562

--- a/src/Conventional_Monitor/image_gen/sorc/conmon_read_uv_IG.fd/histgramuv.f90
+++ b/src/Conventional_Monitor/image_gen/sorc/conmon_read_uv_IG.fd/histgramuv.f90
@@ -25,13 +25,13 @@ subroutine histuv( dtype, rmodnbc, nchan, nxdata, ndata, rmin, rmax, &
    ! local vars
    !
    real,dimension(nchan) :: rmean,rstd 
-   integer,dimension(nchan) :: nmean,nobs,ndata
+   integer,dimension(nchan) :: nobs,ndata
    integer i,j,k,nlev
 
    real,dimension(nchan,400) :: ys
    real,dimension(400) :: xs
    real,dimension(401) :: xs2
-   real maxf,sqr2
+   real sqr2
 
    character*20        :: grads_info_file 
 

--- a/src/Conventional_Monitor/image_gen/sorc/conmon_read_uv_IG.fd/mainread_uv.f90
+++ b/src/Conventional_Monitor/image_gen/sorc/conmon_read_uv_IG.fd/mainread_uv.f90
@@ -5,18 +5,22 @@
 
    implicit none
 
+   external ::  convinfo_read
+   external ::  read_uv
+   external ::  read_uv_mor
+
    character*200 fname
    character*50  fileo, grads_info_file
    character*15  mtype 
 
    real rpress,rlev
 
-   integer nobs,nreal,ntotal,ngross,nreal_in,insubtype
-   integer(4):: ittype,ituse,ntumgrp,ntgroup,ntmiter,iflag
+   integer nreal,insubtype
+   integer(4):: ituse,ntumgrp,ntgroup,ntmiter
    integer isubtype,ncount,ncount_vgc,ncount_gros
 
    real(4) :: ttwind,gtross,etrmax,etrmin,vtar_b,vtar_pg
-   real(4) :: rmiss,vqclmt,vqclmte
+   real(4) :: rmiss
 
    data rmiss/-999.0/ 
 

--- a/src/Conventional_Monitor/image_gen/sorc/conmon_read_uv_IG.fd/read_uv.f90
+++ b/src/Conventional_Monitor/image_gen/sorc/conmon_read_uv_IG.fd/read_uv.f90
@@ -7,7 +7,11 @@
 subroutine read_uv( nreal, dtype, fname, fileo, gtross, rlev, grads_info_file )
 
    implicit none
-  
+ 
+   external :: hist
+   external :: histuv
+   external :: rm_dups
+
    !--------------
    !  interface 
    !
@@ -31,7 +35,7 @@ subroutine read_uv( nreal, dtype, fname, fileo, gtross, rlev, grads_info_file )
    real*4 tiny
    real weight,ddf,rgtross
 
-   integer nobs,ntotal,ngross,nreal_in,nlev
+   integer nobs,ntotal,nreal_in,nlev
    integer i,ndup
    integer ilat,ilon,ipres,itime,iqc,iuse,imuse,iweight,ierr,ierr2,ierr3,iobu,iogu,iobv,iogv
 

--- a/src/Conventional_Monitor/image_gen/sorc/conmon_read_uv_IG.fd/read_uv_mor.f90
+++ b/src/Conventional_Monitor/image_gen/sorc/conmon_read_uv_IG.fd/read_uv_mor.f90
@@ -5,6 +5,10 @@
 subroutine read_uv_mor( nreal, dtype, fname, fileo, gtross, rlev, grads_info_file )
 
    implicit none
+   
+   external ::  hist
+   external ::  histuv
+   external ::  rm_dups
 
    !-------------
    !  interface 
@@ -29,10 +33,10 @@ subroutine read_uv_mor( nreal, dtype, fname, fileo, gtross, rlev, grads_info_fil
    character*50 fileu,filev,fileou2,fileov2
 
    real rgtross
-   integer nobs,ntotal,ngross,nreal_in,nlev
-   integer i,ndup,nlat,nlon,npres,ntime
+   integer nobs,ntotal,nreal_in,nlev
+   integer i,ndup
    integer ilat,ilon,ipres,itime,iqc,iuse,imuse,iweight,ierr,ierr2,ierr3,iobu,iogu,iobv,iogv
-   real(4) :: rmiss,vqclmt,vqclmte
+   real(4) :: rmiss
 
    data rmiss/-999.0/ 
 

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_lev.fd/conmon_read_diag.F90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_lev.fd/conmon_read_diag.F90
@@ -159,7 +159,7 @@ module conmon_read_diag
 
       if ( netcdf ) then
          write(6,*) ' call nc read subroutine'
-         call read_diag_file_nc( input_file, return_all, ctype, intype, expected_nreal, nobs, in_subtype, list )
+         call read_diag_file_nc( input_file, return_all, ctype, intype, nobs, in_subtype, list )
       else
          call read_diag_file_bin( input_file,return_all, ctype, intype, expected_nreal,nobs,in_subtype, list )
       end if
@@ -205,7 +205,7 @@ module conmon_read_diag
       !
       if ( netcdf ) then
          write(6,*) ' call nc retrieve all routine'
-         call read_diag_file_nc( input_file, return_all, ctype, intype, expected_nreal, nobs, in_subtype, list )
+         call read_diag_file_nc( input_file, return_all, ctype, intype, nobs, in_subtype, list )
       else
          write(6,*) ' call bin retrieve all routine'
          call read_diag_file_bin( input_file,return_all, ctype, intype, expected_nreal,nobs,in_subtype, list )
@@ -221,20 +221,18 @@ module conmon_read_diag
    !
    !  NetCDF read routine
    !-------------------------------
-   subroutine read_diag_file_nc( input_file, return_all, ctype, intype, expected_nreal, nobs, in_subtype, list )
+   subroutine read_diag_file_nc( input_file, return_all, ctype, intype, nobs, in_subtype, list )
 
       !--- interface 
       character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
-      type(list_node_t), pointer :: next => null()
-      type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, ftin, total_obs, id, idx
+      integer                    :: ii, ierr, istatus, ftin, id
 
       data ftin / 11 /
 
@@ -270,22 +268,22 @@ module conmon_read_diag
       select case ( trim( adjustl( ctype ) ) )
    
          case ( 'gps' ) 
-            call read_diag_file_gps_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_gps_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 'ps' ) 
-            call read_diag_file_ps_nc(  input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_ps_nc(  return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 'q' ) 
-            call read_diag_file_q_nc(   input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_q_nc(   return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 'sst' )
-            call read_diag_file_sst_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_sst_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 't' ) 
-            call read_diag_file_t_nc(   input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_t_nc(   return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 'uv' ) 
-            call read_diag_file_uv_nc(  input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_uv_nc(  return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case default
             print *, 'ERROR:  unmatched ctype :', ctype
@@ -318,21 +316,20 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for ps data types in netcdf files
    !
-   subroutine read_diag_file_ps_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
+   subroutine read_diag_file_ps_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -359,7 +356,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Observation                     !  (obs)
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_adjusted     !  (obs)
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_unadjusted   !  (obs)
-      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_ps_nc'
@@ -521,21 +517,20 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for q data types in netcdf files
    !
-   subroutine read_diag_file_q_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
+   subroutine read_diag_file_q_nc( return_all, ftin, ctype, intype, nobs,in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -563,7 +558,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_adjusted     !  (obs)
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_unadjusted   !  (obs)
       real(r_single), dimension(:), allocatable    :: Forecast_Saturation_Spec_Hum    !  (obs)
-      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_q_nc'
@@ -736,21 +730,20 @@ module conmon_read_diag
    !  NOTE2:  There are known discrepencies between the contents
    !          of sst obs in binary and NetCDF files. 
    !
-   subroutine read_diag_file_sst_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
+   subroutine read_diag_file_sst_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -781,7 +774,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: DiurnalWarming_at_zob           !  (obs)
       real(r_single), dimension(:), allocatable    :: SkinLayerCooling_at_zob         !  (obs)
       real(r_single), dimension(:), allocatable    :: Sensitivity_Tzob_Tr             !  (obs)
-      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_sst_nc'
@@ -966,21 +958,20 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for t data types in netcdf files
    !
-   subroutine read_diag_file_t_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+   subroutine read_diag_file_t_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx, bcor_terms
+      integer                    :: ii, ierr, total_obs, idx, bcor_terms
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1010,18 +1001,18 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Data_Pof                        !  (obs) 
       real(r_single), dimension(:), allocatable    :: Data_Vertical_Velocity          !  (obs)
       real(r_single), dimension(:,:), allocatable  :: Bias_Correction_Terms           !  (nobs, Bias_Correction_Terms_arr_dim)
-      integer(i_kind)                              :: idate 
       integer(i_kind)                              :: jj
 
       print *, ' '
       print *, '      --> read_diag_file_t_nc'
 
-      print *, '            input_file = ', input_file
       print *, '            ftin       = ', ftin
       print *, '            ctype      = ', ctype
       print *, '            intype     = ', intype  
-      print *, '            expected_nreal = ', expected_nreal 
       print *, '            in_subtype = ', in_subtype
+      print *, '          nopen_ncdiag = ', nopen_ncdiag
+
+      print *, '            ii         = ', ii
 
 
       !--- get NetCDF file dimensions
@@ -1204,21 +1195,20 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for uv data types in netcdf files
    !
-   subroutine read_diag_file_uv_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+   subroutine read_diag_file_uv_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1250,7 +1240,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: v_Observation                   !  (obs)
       real(r_single), dimension(:), allocatable    :: v_Obs_Minus_Forecast_adjusted   !  (obs)
       real(r_single), dimension(:), allocatable    :: v_Obs_Minus_Forecast_unadjusted !  (obs)
-      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_uv_nc'
@@ -1435,21 +1424,20 @@ module conmon_read_diag
    !          in binary and NetCDF formatted diag files. See
    !          comments below.
    !
-   subroutine read_diag_file_gps_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
+   subroutine read_diag_file_gps_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
  
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1462,14 +1450,12 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Latitude                          !  (obs)
       real(r_single), dimension(:), allocatable    :: Longitude                         !  (obs)
       real(r_single), dimension(:), allocatable    :: Incremental_Bending_Angle         !  (obs)
-      real(r_single), dimension(:), allocatable    :: Station_Elevation                 !  (obs)
       real(r_single), dimension(:), allocatable    :: Pressure                          !  (obs)
       real(r_single), dimension(:), allocatable    :: Height                            !  (obs)
       real(r_single), dimension(:), allocatable    :: Time                              !  (obs)
       real(r_single), dimension(:), allocatable    :: Model_Elevation                   !  (obs)
       real(r_single), dimension(:), allocatable    :: Setup_QC_Mark                     !  (obs)
       real(r_single), dimension(:), allocatable    :: Prep_Use_Flag                     !  (obs)
-      real(r_single), dimension(:), allocatable    :: Nonlinear_QC_Var_Jb               !  (obs)
       real(r_single), dimension(:), allocatable    :: Nonlinear_QC_Rel_Wgt              !  (obs)
       real(r_single), dimension(:), allocatable    :: Analysis_Use_Flag                 !  (obs)
       real(r_single), dimension(:), allocatable    :: Errinv_Input                      !  (obs)
@@ -1481,8 +1467,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: GPS_Type                          !  (obs)
       real(r_single), dimension(:), allocatable    :: Temperature_at_Obs_Location       !  (obs)
       real(r_single), dimension(:), allocatable    :: Specific_Humidity_at_Obs_Location !  (obs)
-
-      integer(i_kind)                              :: idate 
 
 
 
@@ -1699,11 +1683,9 @@ module conmon_read_diag
       character(8),allocatable,dimension(:)  :: cdiag 
 
       character(3)   :: dtype
-      character(10)  :: otype
-      character(15)  :: fileo,fileo_subtyp
 
-      integer nchar,file_nreal,i,ii,mype,idate,iflag,file_itype,iscater,igrads
-      integer lunin,lunot,ldtype,file_subtype
+      integer nchar,file_nreal,i,ii,mype,idate,iflag,file_itype
+      integer lunin,file_subtype
       integer idx,ioff02
 
       data lunin / 11 /

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_lev.fd/conmon_read_diag.F90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_lev.fd/conmon_read_diag.F90
@@ -159,7 +159,7 @@ module conmon_read_diag
 
       if ( netcdf ) then
          write(6,*) ' call nc read subroutine'
-         call read_diag_file_nc( input_file, return_all, ctype, intype, nobs, in_subtype, list )
+         call read_diag_file_nc( input_file, return_all, ctype, intype, expected_nreal, nobs, in_subtype, list )
       else
          call read_diag_file_bin( input_file,return_all, ctype, intype, expected_nreal,nobs,in_subtype, list )
       end if
@@ -205,7 +205,7 @@ module conmon_read_diag
       !
       if ( netcdf ) then
          write(6,*) ' call nc retrieve all routine'
-         call read_diag_file_nc( input_file, return_all, ctype, intype, nobs, in_subtype, list )
+         call read_diag_file_nc( input_file, return_all, ctype, intype, expected_nreal, nobs, in_subtype, list )
       else
          write(6,*) ' call bin retrieve all routine'
          call read_diag_file_bin( input_file,return_all, ctype, intype, expected_nreal,nobs,in_subtype, list )
@@ -221,18 +221,20 @@ module conmon_read_diag
    !
    !  NetCDF read routine
    !-------------------------------
-   subroutine read_diag_file_nc( input_file, return_all, ctype, intype, nobs, in_subtype, list )
+   subroutine read_diag_file_nc( input_file, return_all, ctype, intype, expected_nreal, nobs, in_subtype, list )
 
       !--- interface 
       character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, in_subtype
+      integer, intent(in)        :: intype, expected_nreal, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
-      integer                    :: ii, ierr, istatus, ftin, id
+      type(list_node_t), pointer :: next => null()
+      type(data_ptr)             :: ptr
+      integer                    :: ii, ierr, istatus, ftin, total_obs, id, idx
 
       data ftin / 11 /
 
@@ -268,22 +270,22 @@ module conmon_read_diag
       select case ( trim( adjustl( ctype ) ) )
    
          case ( 'gps' ) 
-            call read_diag_file_gps_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
+            call read_diag_file_gps_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
 
          case ( 'ps' ) 
-            call read_diag_file_ps_nc(  return_all, ftin, ctype, intype, nobs, in_subtype, list )
+            call read_diag_file_ps_nc(  input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
 
          case ( 'q' ) 
-            call read_diag_file_q_nc(   return_all, ftin, ctype, intype, nobs, in_subtype, list )
+            call read_diag_file_q_nc(   input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
 
          case ( 'sst' )
-            call read_diag_file_sst_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
+            call read_diag_file_sst_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
 
          case ( 't' ) 
-            call read_diag_file_t_nc(   return_all, ftin, ctype, intype, nobs, in_subtype, list )
+            call read_diag_file_t_nc(   input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
 
          case ( 'uv' ) 
-            call read_diag_file_uv_nc(  return_all, ftin, ctype, intype, nobs, in_subtype, list )
+            call read_diag_file_uv_nc(  input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
 
          case default
             print *, 'ERROR:  unmatched ctype :', ctype
@@ -316,20 +318,21 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for ps data types in netcdf files
    !
-   subroutine read_diag_file_ps_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
+   subroutine read_diag_file_ps_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
   
       !--- interface 
+      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, in_subtype
+      integer, intent(in)        :: intype, expected_nreal, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, total_obs, idx
+      integer                    :: ii, ierr, istatus, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -356,6 +359,7 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Observation                     !  (obs)
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_adjusted     !  (obs)
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_unadjusted   !  (obs)
+      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_ps_nc'
@@ -517,20 +521,21 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for q data types in netcdf files
    !
-   subroutine read_diag_file_q_nc( return_all, ftin, ctype, intype, nobs,in_subtype, list )
+   subroutine read_diag_file_q_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
   
       !--- interface 
+      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, in_subtype
+      integer, intent(in)        :: intype, expected_nreal, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, total_obs, idx
+      integer                    :: ii, ierr, istatus, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -558,6 +563,7 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_adjusted     !  (obs)
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_unadjusted   !  (obs)
       real(r_single), dimension(:), allocatable    :: Forecast_Saturation_Spec_Hum    !  (obs)
+      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_q_nc'
@@ -730,20 +736,21 @@ module conmon_read_diag
    !  NOTE2:  There are known discrepencies between the contents
    !          of sst obs in binary and NetCDF files. 
    !
-   subroutine read_diag_file_sst_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
+   subroutine read_diag_file_sst_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
   
       !--- interface 
+      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, in_subtype
+      integer, intent(in)        :: intype, expected_nreal, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, total_obs, idx
+      integer                    :: ii, ierr, istatus, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -774,6 +781,7 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: DiurnalWarming_at_zob           !  (obs)
       real(r_single), dimension(:), allocatable    :: SkinLayerCooling_at_zob         !  (obs)
       real(r_single), dimension(:), allocatable    :: Sensitivity_Tzob_Tr             !  (obs)
+      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_sst_nc'
@@ -958,20 +966,21 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for t data types in netcdf files
    !
-   subroutine read_diag_file_t_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
+   subroutine read_diag_file_t_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
   
       !--- interface 
+      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, in_subtype
+      integer, intent(in)        :: intype, expected_nreal, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, total_obs, idx, bcor_terms
+      integer                    :: ii, ierr, istatus, total_obs, idx, bcor_terms
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1001,18 +1010,18 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Data_Pof                        !  (obs) 
       real(r_single), dimension(:), allocatable    :: Data_Vertical_Velocity          !  (obs)
       real(r_single), dimension(:,:), allocatable  :: Bias_Correction_Terms           !  (nobs, Bias_Correction_Terms_arr_dim)
+      integer(i_kind)                              :: idate 
       integer(i_kind)                              :: jj
 
       print *, ' '
       print *, '      --> read_diag_file_t_nc'
 
+      print *, '            input_file = ', input_file
       print *, '            ftin       = ', ftin
       print *, '            ctype      = ', ctype
       print *, '            intype     = ', intype  
+      print *, '            expected_nreal = ', expected_nreal 
       print *, '            in_subtype = ', in_subtype
-      print *, '          nopen_ncdiag = ', nopen_ncdiag
-
-      print *, '            ii         = ', ii
 
 
       !--- get NetCDF file dimensions
@@ -1195,20 +1204,21 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for uv data types in netcdf files
    !
-   subroutine read_diag_file_uv_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
+   subroutine read_diag_file_uv_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
   
       !--- interface 
+      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, in_subtype
+      integer, intent(in)        :: intype, expected_nreal, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, total_obs, idx
+      integer                    :: ii, ierr, istatus, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1240,6 +1250,7 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: v_Observation                   !  (obs)
       real(r_single), dimension(:), allocatable    :: v_Obs_Minus_Forecast_adjusted   !  (obs)
       real(r_single), dimension(:), allocatable    :: v_Obs_Minus_Forecast_unadjusted !  (obs)
+      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_uv_nc'
@@ -1424,20 +1435,21 @@ module conmon_read_diag
    !          in binary and NetCDF formatted diag files. See
    !          comments below.
    !
-   subroutine read_diag_file_gps_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
+   subroutine read_diag_file_gps_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
  
       !--- interface 
+      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, in_subtype
+      integer, intent(in)        :: intype, expected_nreal, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, total_obs, idx
+      integer                    :: ii, ierr, istatus, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1450,12 +1462,14 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Latitude                          !  (obs)
       real(r_single), dimension(:), allocatable    :: Longitude                         !  (obs)
       real(r_single), dimension(:), allocatable    :: Incremental_Bending_Angle         !  (obs)
+      real(r_single), dimension(:), allocatable    :: Station_Elevation                 !  (obs)
       real(r_single), dimension(:), allocatable    :: Pressure                          !  (obs)
       real(r_single), dimension(:), allocatable    :: Height                            !  (obs)
       real(r_single), dimension(:), allocatable    :: Time                              !  (obs)
       real(r_single), dimension(:), allocatable    :: Model_Elevation                   !  (obs)
       real(r_single), dimension(:), allocatable    :: Setup_QC_Mark                     !  (obs)
       real(r_single), dimension(:), allocatable    :: Prep_Use_Flag                     !  (obs)
+      real(r_single), dimension(:), allocatable    :: Nonlinear_QC_Var_Jb               !  (obs)
       real(r_single), dimension(:), allocatable    :: Nonlinear_QC_Rel_Wgt              !  (obs)
       real(r_single), dimension(:), allocatable    :: Analysis_Use_Flag                 !  (obs)
       real(r_single), dimension(:), allocatable    :: Errinv_Input                      !  (obs)
@@ -1467,6 +1481,8 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: GPS_Type                          !  (obs)
       real(r_single), dimension(:), allocatable    :: Temperature_at_Obs_Location       !  (obs)
       real(r_single), dimension(:), allocatable    :: Specific_Humidity_at_Obs_Location !  (obs)
+
+      integer(i_kind)                              :: idate 
 
 
 
@@ -1683,9 +1699,11 @@ module conmon_read_diag
       character(8),allocatable,dimension(:)  :: cdiag 
 
       character(3)   :: dtype
+      character(10)  :: otype
+      character(15)  :: fileo,fileo_subtyp
 
-      integer nchar,file_nreal,i,ii,mype,idate,iflag,file_itype
-      integer lunin,file_subtype
+      integer nchar,file_nreal,i,ii,mype,idate,iflag,file_itype,iscater,igrads
+      integer lunin,lunot,ldtype,file_subtype
       integer idx,ioff02
 
       data lunin / 11 /

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_lev.fd/conmon_read_diag.F90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_lev.fd/conmon_read_diag.F90
@@ -232,9 +232,7 @@ module conmon_read_diag
       type(list_node_t), pointer :: list
 
       !--- local vars
-      type(list_node_t), pointer :: next => null()
-      type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, ftin, total_obs, id, idx
+      integer                    :: ii, ierr, ftin, id
 
       data ftin / 11 /
 
@@ -251,7 +249,6 @@ module conmon_read_diag
       endif
 
       call nc_diag_read_init( input_file, ftin )
-      istatus=0
 
       do ii = 1, MAX_OPEN_NCDIAG
 
@@ -332,7 +329,7 @@ module conmon_read_diag
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -359,7 +356,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Observation                     !  (obs)
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_adjusted     !  (obs)
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_unadjusted   !  (obs)
-      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_ps_nc'
@@ -535,7 +531,7 @@ module conmon_read_diag
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -563,7 +559,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_adjusted     !  (obs)
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_unadjusted   !  (obs)
       real(r_single), dimension(:), allocatable    :: Forecast_Saturation_Spec_Hum    !  (obs)
-      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_q_nc'
@@ -750,7 +745,7 @@ module conmon_read_diag
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -781,7 +776,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: DiurnalWarming_at_zob           !  (obs)
       real(r_single), dimension(:), allocatable    :: SkinLayerCooling_at_zob         !  (obs)
       real(r_single), dimension(:), allocatable    :: Sensitivity_Tzob_Tr             !  (obs)
-      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_sst_nc'
@@ -980,7 +974,7 @@ module conmon_read_diag
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx, bcor_terms
+      integer                    :: ii, ierr, total_obs, idx, bcor_terms
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1010,7 +1004,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Data_Pof                        !  (obs) 
       real(r_single), dimension(:), allocatable    :: Data_Vertical_Velocity          !  (obs)
       real(r_single), dimension(:,:), allocatable  :: Bias_Correction_Terms           !  (nobs, Bias_Correction_Terms_arr_dim)
-      integer(i_kind)                              :: idate 
       integer(i_kind)                              :: jj
 
       print *, ' '
@@ -1218,7 +1211,7 @@ module conmon_read_diag
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1250,7 +1243,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: v_Observation                   !  (obs)
       real(r_single), dimension(:), allocatable    :: v_Obs_Minus_Forecast_adjusted   !  (obs)
       real(r_single), dimension(:), allocatable    :: v_Obs_Minus_Forecast_unadjusted !  (obs)
-      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_uv_nc'
@@ -1449,7 +1441,7 @@ module conmon_read_diag
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1481,9 +1473,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: GPS_Type                          !  (obs)
       real(r_single), dimension(:), allocatable    :: Temperature_at_Obs_Location       !  (obs)
       real(r_single), dimension(:), allocatable    :: Specific_Humidity_at_Obs_Location !  (obs)
-
-      integer(i_kind)                              :: idate 
-
 
 
       print *, ' '
@@ -1699,11 +1688,9 @@ module conmon_read_diag
       character(8),allocatable,dimension(:)  :: cdiag 
 
       character(3)   :: dtype
-      character(10)  :: otype
-      character(15)  :: fileo,fileo_subtyp
 
-      integer nchar,file_nreal,i,ii,mype,idate,iflag,file_itype,iscater,igrads
-      integer lunin,lunot,ldtype,file_subtype
+      integer nchar,file_nreal,i,ii,mype,idate,iflag,file_itype
+      integer lunin,file_subtype
       integer idx,ioff02
 
       data lunin / 11 /

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_lev.fd/grads_lev.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_lev.fd/grads_lev.f90
@@ -8,12 +8,14 @@
 
 
 subroutine grads_lev(fileo,ifileo,nobs,nreal,nlev,plev,iscater,igrads,&
-                        levcard,hint,isubtype,subtype,list,run)
+                        hint,subtype,list,run)
 
    use generic_list
    use data
 
    implicit none
+
+   external ::  rm_dups
 
    type(list_node_t), pointer   :: list
    type(list_node_t), pointer   :: next => null()
@@ -29,9 +31,7 @@ subroutine grads_lev(fileo,ifileo,nobs,nreal,nlev,plev,iscater,igrads,&
    character(3) ::  run             ! ges or anl
 
    character(30) :: files, filegrad, file_nobs
-   character(10) :: levcard 
 
-   integer(4):: isubtype
    integer i,j,k,ctr,obs_ctr
    integer ilat,ilon,ipres,itime,iweight,ndup
 

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_lev.fd/grads_lev.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_lev.fd/grads_lev.f90
@@ -8,14 +8,12 @@
 
 
 subroutine grads_lev(fileo,ifileo,nobs,nreal,nlev,plev,iscater,igrads,&
-                        hint,subtype,list,run)
+                        levcard,hint,isubtype,subtype,list,run)
 
    use generic_list
    use data
 
    implicit none
-
-   external ::  rm_dups
 
    type(list_node_t), pointer   :: list
    type(list_node_t), pointer   :: next => null()
@@ -31,7 +29,9 @@ subroutine grads_lev(fileo,ifileo,nobs,nreal,nlev,plev,iscater,igrads,&
    character(3) ::  run             ! ges or anl
 
    character(30) :: files, filegrad, file_nobs
+   character(10) :: levcard 
 
+   integer(4):: isubtype
    integer i,j,k,ctr,obs_ctr
    integer ilat,ilon,ipres,itime,iweight,ndup
 

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_lev.fd/grads_lev.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_lev.fd/grads_lev.f90
@@ -15,6 +15,8 @@ subroutine grads_lev(fileo,ifileo,nobs,nreal,nlev,plev,iscater,igrads,&
 
    implicit none
 
+   external :: rm_dups
+
    type(list_node_t), pointer   :: list
    type(list_node_t), pointer   :: next => null()
    type(data_ptr)               :: ptr

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_lev.fd/maingrads_lev.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_lev.fd/maingrads_lev.f90
@@ -39,7 +39,7 @@
    real(4),dimension(6) :: pacft 
    real(4),dimension(4) :: pupair
    real(4),dimension(10) :: palllev
-   character(10) :: levcard,fileo,stype 
+   character(10) :: levcard,stype 
    character(3) :: intype
    character(3) :: subtype
    integer nreal,iscater,igrads 
@@ -47,8 +47,6 @@
    real hint
 
    type(list_node_t), pointer   :: list => null()
-   type(list_node_t), pointer   :: next => null()
-   type(data_ptr)               :: ptr
 
    !--- namelist with defaults
    logical               :: netcdf              = .false.

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_lev.fd/maingrads_lev.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_lev.fd/maingrads_lev.f90
@@ -18,14 +18,13 @@
    interface
 
       subroutine grads_lev(fileo,ifileo,nobs,nreal,nlev,plev,iscater,igrads, &
-                           levcard,hint,isubtype,subtype,list,run)
+                           hint,subtype,list,run)
          use generic_list
 
          integer ifileo
          character(ifileo)              :: fileo
-         integer                        :: nobs,nreal,nlev,iscater,igrads,isubtype
+         integer                        :: nobs,nreal,nlev,iscater,igrads
          real(4),dimension(nlev)        :: plev
-         character(10)                  :: levcard
          real*4                         :: hint
          character(3)                   :: subtype
          type(list_node_t), pointer     :: list
@@ -39,7 +38,7 @@
    real(4),dimension(6) :: pacft 
    real(4),dimension(4) :: pupair
    real(4),dimension(10) :: palllev
-   character(10) :: levcard,fileo,stype 
+   character(10) :: levcard,stype 
    character(3) :: intype
    character(3) :: subtype
    integer nreal,iscater,igrads 
@@ -47,8 +46,6 @@
    real hint
 
    type(list_node_t), pointer   :: list => null()
-   type(list_node_t), pointer   :: next => null()
-   type(data_ptr)               :: ptr
 
    !--- namelist with defaults
    logical               :: netcdf              = .false.
@@ -84,16 +81,16 @@
    if( nobs > 0 ) then
       if(trim(levcard) == 'alllev' ) then
          call grads_lev(stype,lstype,nobs,nreal,n_alllev,palllev,iscater, &
-                        igrads,levcard,hint,isubtype,subtype,list,run)
+                        igrads,hint,subtype,list,run)
       else if (trim(levcard) == 'acft' ) then
          call grads_lev(stype,lstype,nobs,nreal,n_acft,pacft,iscater,igrads,&
-                        levcard,hint,isubtype,subtype,list,run)
+                        hint,subtype,list,run)
       else if(trim(levcard) == 'lowlev' ) then
          call grads_lev(stype,lstype,nobs,nreal,n_lowlev,plowlev,iscater,&
-                        igrads,levcard,hint,isubtype,subtype,list,run)
+                        igrads,hint,subtype,list,run)
       else if(trim(levcard) == 'upair' ) then
          call grads_lev(stype,lstype,nobs,nreal,n_upair,pupair,iscater,&
-                        igrads,levcard,hint,isubtype,subtype,list,run)
+                        igrads,hint,subtype,list,run)
       end if
    else
       print *, 'NOBS <= 0, NO OUTPUT GENERATED' 

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_lev.fd/maingrads_lev.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_lev.fd/maingrads_lev.f90
@@ -18,13 +18,14 @@
    interface
 
       subroutine grads_lev(fileo,ifileo,nobs,nreal,nlev,plev,iscater,igrads, &
-                           hint,subtype,list,run)
+                           levcard,hint,isubtype,subtype,list,run)
          use generic_list
 
          integer ifileo
          character(ifileo)              :: fileo
-         integer                        :: nobs,nreal,nlev,iscater,igrads
+         integer                        :: nobs,nreal,nlev,iscater,igrads,isubtype
          real(4),dimension(nlev)        :: plev
+         character(10)                  :: levcard
          real*4                         :: hint
          character(3)                   :: subtype
          type(list_node_t), pointer     :: list
@@ -38,7 +39,7 @@
    real(4),dimension(6) :: pacft 
    real(4),dimension(4) :: pupair
    real(4),dimension(10) :: palllev
-   character(10) :: levcard,stype 
+   character(10) :: levcard,fileo,stype 
    character(3) :: intype
    character(3) :: subtype
    integer nreal,iscater,igrads 
@@ -46,6 +47,8 @@
    real hint
 
    type(list_node_t), pointer   :: list => null()
+   type(list_node_t), pointer   :: next => null()
+   type(data_ptr)               :: ptr
 
    !--- namelist with defaults
    logical               :: netcdf              = .false.
@@ -81,16 +84,16 @@
    if( nobs > 0 ) then
       if(trim(levcard) == 'alllev' ) then
          call grads_lev(stype,lstype,nobs,nreal,n_alllev,palllev,iscater, &
-                        igrads,hint,subtype,list,run)
+                        igrads,levcard,hint,isubtype,subtype,list,run)
       else if (trim(levcard) == 'acft' ) then
          call grads_lev(stype,lstype,nobs,nreal,n_acft,pacft,iscater,igrads,&
-                        hint,subtype,list,run)
+                        levcard,hint,isubtype,subtype,list,run)
       else if(trim(levcard) == 'lowlev' ) then
          call grads_lev(stype,lstype,nobs,nreal,n_lowlev,plowlev,iscater,&
-                        igrads,hint,subtype,list,run)
+                        igrads,levcard,hint,isubtype,subtype,list,run)
       else if(trim(levcard) == 'upair' ) then
          call grads_lev(stype,lstype,nobs,nreal,n_upair,pupair,iscater,&
-                        igrads,hint,subtype,list,run)
+                        igrads,levcard,hint,isubtype,subtype,list,run)
       end if
    else
       print *, 'NOBS <= 0, NO OUTPUT GENERATED' 

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_mandlev.fd/conmon_read_diag.F90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_mandlev.fd/conmon_read_diag.F90
@@ -232,9 +232,7 @@ module conmon_read_diag
       type(list_node_t), pointer :: list
 
       !--- local vars
-      type(list_node_t), pointer :: next => null()
-      type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, ftin, total_obs, id, idx
+      integer                    :: ii, ierr, istatus, ftin, id
 
       data ftin / 11 /
 
@@ -332,7 +330,7 @@ module conmon_read_diag
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -359,7 +357,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Observation                     !  (obs)
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_adjusted     !  (obs)
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_unadjusted   !  (obs)
-      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_ps_nc'
@@ -535,7 +532,7 @@ module conmon_read_diag
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -563,7 +560,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_adjusted     !  (obs)
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_unadjusted   !  (obs)
       real(r_single), dimension(:), allocatable    :: Forecast_Saturation_Spec_Hum    !  (obs)
-      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_q_nc'
@@ -750,7 +746,7 @@ module conmon_read_diag
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -781,7 +777,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: DiurnalWarming_at_zob           !  (obs)
       real(r_single), dimension(:), allocatable    :: SkinLayerCooling_at_zob         !  (obs)
       real(r_single), dimension(:), allocatable    :: Sensitivity_Tzob_Tr             !  (obs)
-      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_sst_nc'
@@ -980,7 +975,7 @@ module conmon_read_diag
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx, bcor_terms
+      integer                    :: ii, ierr, total_obs, idx, bcor_terms
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1010,7 +1005,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Data_Pof                        !  (obs) 
       real(r_single), dimension(:), allocatable    :: Data_Vertical_Velocity          !  (obs)
       real(r_single), dimension(:,:), allocatable  :: Bias_Correction_Terms           !  (nobs, Bias_Correction_Terms_arr_dim)
-      integer(i_kind)                              :: idate 
       integer(i_kind)                              :: jj
 
       print *, ' '
@@ -1218,7 +1212,7 @@ module conmon_read_diag
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1250,7 +1244,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: v_Observation                   !  (obs)
       real(r_single), dimension(:), allocatable    :: v_Obs_Minus_Forecast_adjusted   !  (obs)
       real(r_single), dimension(:), allocatable    :: v_Obs_Minus_Forecast_unadjusted !  (obs)
-      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_uv_nc'
@@ -1449,7 +1442,7 @@ module conmon_read_diag
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1481,8 +1474,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: GPS_Type                          !  (obs)
       real(r_single), dimension(:), allocatable    :: Temperature_at_Obs_Location       !  (obs)
       real(r_single), dimension(:), allocatable    :: Specific_Humidity_at_Obs_Location !  (obs)
-
-      integer(i_kind)                              :: idate 
 
 
 
@@ -1699,11 +1690,9 @@ module conmon_read_diag
       character(8),allocatable,dimension(:)  :: cdiag 
 
       character(3)   :: dtype
-      character(10)  :: otype
-      character(15)  :: fileo,fileo_subtyp
 
-      integer nchar,file_nreal,i,ii,mype,idate,iflag,file_itype,iscater,igrads
-      integer lunin,lunot,ldtype,file_subtype
+      integer nchar,file_nreal,i,ii,mype,idate,iflag,file_itype
+      integer lunin,file_subtype
       integer idx,ioff02
 
       data lunin / 11 /

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_mandlev.fd/grads_mandlev.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_mandlev.fd/grads_mandlev.f90
@@ -13,7 +13,9 @@ subroutine grads_mandlev(fileo,ifileo,nobs,nreal,nlev,plev,iscater,igrads,&
    use data
 
    implicit none
- 
+
+   external :: rm_dups
+
    type(list_node_t), pointer   :: list
    type(list_node_t), pointer   :: next => null()
    type(data_ptr)               :: ptr
@@ -21,8 +23,6 @@ subroutine grads_mandlev(fileo,ifileo,nobs,nreal,nlev,plev,iscater,igrads,&
    real(4),allocatable,dimension(:,:)  :: rdiag_m2
    character(8),allocatable,dimension(:) :: cdiag
   
-   real(4),dimension(nreal) :: rdummy
-   character(8) cdummy 
    real(4),dimension(nlev) :: plev
 
    real(4) rlat,rlon,rp
@@ -32,11 +32,11 @@ subroutine grads_mandlev(fileo,ifileo,nobs,nreal,nlev,plev,iscater,igrads,&
    character(ifileo) :: fileo 
    character(30)  :: files,filegrads 
    character(8)  :: stidend
-   integer nobs,nreal,nlfag,nflag0,nlev,nlev0,getlev,iscater,igrads,nflg0
+   integer nobs,nreal,nreal_m2,nflag0,nlev,nlev0,getlev,iscater,igrads,nflg0
    real*4               :: rtim,xlat0,xlon0
-   character(30)        :: filein, file_nobs
+   character(30)        :: file_nobs
 
-   integer              :: i,j,ii,k,nreal_m2,ctr,obs_ctr
+   integer              :: i,j,ii,k,ctr,obs_ctr
    integer              :: ilat,ilon,ipres,itime,iweight,ndup
    integer(4)           :: isubtype
  

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_mandlev.fd/maingrads_mandlev.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_mandlev.fd/maingrads_mandlev.f90
@@ -34,15 +34,13 @@ program maingrads_mandlev
 
 
    real(4),dimension(13) :: pmand 
-   character(10) :: fileo,stype 
+   character(10) :: stype 
    character(3) :: intype
    character(3) :: subtype
-   integer nreal,nreal_m2,iscater,igrads,isubtype,itype
-   integer n_alllev,n_acft,n_lowlev,n_upair,nobs,lstype
+   integer nreal,iscater,igrads,isubtype,itype
+   integer nobs,lstype
 
    type(list_node_t), pointer   :: list => null()
-   type(list_node_t), pointer   :: next => null()
-   type(data_ptr)               :: ptr
 
    !--- namelist with defaults
    logical               :: netcdf              = .false.

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfc.fd/conmon_read_diag.F90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfc.fd/conmon_read_diag.F90
@@ -159,7 +159,7 @@ module conmon_read_diag
 
       if ( netcdf ) then
          write(6,*) ' call nc read subroutine'
-         call read_diag_file_nc( input_file, return_all, ctype, intype, nobs, in_subtype, list )
+         call read_diag_file_nc( input_file, return_all, ctype, intype, expected_nreal, nobs, in_subtype, list )
       else
          call read_diag_file_bin( input_file,return_all, ctype, intype, expected_nreal,nobs,in_subtype, list )
       end if
@@ -205,7 +205,7 @@ module conmon_read_diag
       !
       if ( netcdf ) then
          write(6,*) ' call nc retrieve all routine'
-         call read_diag_file_nc( input_file, return_all, ctype, intype, nobs, in_subtype, list )
+         call read_diag_file_nc( input_file, return_all, ctype, intype, expected_nreal, nobs, in_subtype, list )
       else
          write(6,*) ' call bin retrieve all routine'
          call read_diag_file_bin( input_file,return_all, ctype, intype, expected_nreal,nobs,in_subtype, list )
@@ -221,18 +221,20 @@ module conmon_read_diag
    !
    !  NetCDF read routine
    !-------------------------------
-   subroutine read_diag_file_nc( input_file, return_all, ctype, intype, nobs, in_subtype, list )
+   subroutine read_diag_file_nc( input_file, return_all, ctype, intype, expected_nreal, nobs, in_subtype, list )
 
       !--- interface 
       character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, in_subtype
+      integer, intent(in)        :: intype, expected_nreal, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
-      integer                    :: ii, ierr, ftin, id
+      type(list_node_t), pointer :: next => null()
+      type(data_ptr)             :: ptr
+      integer                    :: ii, ierr, istatus, ftin, total_obs, id, idx
 
       data ftin / 11 /
 
@@ -249,7 +251,7 @@ module conmon_read_diag
       endif
 
       call nc_diag_read_init( input_file, ftin )
-      print *, '  ftin: ', ftin
+      istatus=0
 
       do ii = 1, MAX_OPEN_NCDIAG
 
@@ -268,22 +270,22 @@ module conmon_read_diag
       select case ( trim( adjustl( ctype ) ) )
    
          case ( 'gps' ) 
-            call read_diag_file_gps_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
+            call read_diag_file_gps_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
 
          case ( 'ps' ) 
-            call read_diag_file_ps_nc(  return_all, ftin, ctype, intype, nobs, in_subtype, list )
+            call read_diag_file_ps_nc(  input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
 
          case ( 'q' ) 
-            call read_diag_file_q_nc(   return_all, ftin, ctype, intype, nobs, in_subtype, list )
+            call read_diag_file_q_nc(   input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
 
          case ( 'sst' )
-            call read_diag_file_sst_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
+            call read_diag_file_sst_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
 
          case ( 't' ) 
-            call read_diag_file_t_nc(   return_all, ftin, ctype, intype, nobs, in_subtype, list )
+            call read_diag_file_t_nc(   input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
 
          case ( 'uv' ) 
-            call read_diag_file_uv_nc(  return_all, ftin, ctype, intype, nobs, in_subtype, list )
+            call read_diag_file_uv_nc(  input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
 
          case default
             print *, 'ERROR:  unmatched ctype :', ctype
@@ -316,20 +318,21 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for ps data types in netcdf files
    !
-   subroutine read_diag_file_ps_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
+   subroutine read_diag_file_ps_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
   
       !--- interface 
+      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, in_subtype
+      integer, intent(in)        :: intype, expected_nreal, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, total_obs, idx
+      integer                    :: ii, ierr, istatus, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -356,6 +359,7 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Observation                     !  (obs)
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_adjusted     !  (obs)
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_unadjusted   !  (obs)
+      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_ps_nc'
@@ -517,20 +521,21 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for q data types in netcdf files
    !
-   subroutine read_diag_file_q_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
+   subroutine read_diag_file_q_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
   
       !--- interface 
+      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, in_subtype
+      integer, intent(in)        :: intype, expected_nreal, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, total_obs, idx
+      integer                    :: ii, ierr, istatus, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -558,6 +563,7 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_adjusted     !  (obs)
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_unadjusted   !  (obs)
       real(r_single), dimension(:), allocatable    :: Forecast_Saturation_Spec_Hum    !  (obs)
+      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_q_nc'
@@ -730,20 +736,21 @@ module conmon_read_diag
    !  NOTE2:  There are known discrepencies between the contents
    !          of sst obs in binary and NetCDF files. 
    !
-   subroutine read_diag_file_sst_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
+   subroutine read_diag_file_sst_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
   
       !--- interface 
+      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, in_subtype
+      integer, intent(in)        :: intype, expected_nreal, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, total_obs, idx
+      integer                    :: ii, ierr, istatus, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -774,6 +781,7 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: DiurnalWarming_at_zob           !  (obs)
       real(r_single), dimension(:), allocatable    :: SkinLayerCooling_at_zob         !  (obs)
       real(r_single), dimension(:), allocatable    :: Sensitivity_Tzob_Tr             !  (obs)
+      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_sst_nc'
@@ -958,20 +966,21 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for t data types in netcdf files
    !
-   subroutine read_diag_file_t_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
+   subroutine read_diag_file_t_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
   
       !--- interface 
+      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, in_subtype
+      integer, intent(in)        :: intype, expected_nreal, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, total_obs, idx, bcor_terms
+      integer                    :: ii, ierr, istatus, total_obs, idx, bcor_terms
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1001,22 +1010,25 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Data_Pof                        !  (obs) 
       real(r_single), dimension(:), allocatable    :: Data_Vertical_Velocity          !  (obs)
       real(r_single), dimension(:,:), allocatable  :: Bias_Correction_Terms           !  (nobs, Bias_Correction_Terms_arr_dim)
+      integer(i_kind)                              :: idate 
       integer(i_kind)                              :: jj
 
       print *, ' '
       print *, '      --> read_diag_file_t_nc'
 
-      print *, '            return_all = ', return_all
+      print *, '            input_file = ', input_file
       print *, '            ftin       = ', ftin
       print *, '            ctype      = ', ctype
       print *, '            intype     = ', intype  
+      print *, '            expected_nreal = ', expected_nreal 
       print *, '            in_subtype = ', in_subtype
+
 
       !--- get NetCDF file dimensions
       !
       if( nc_diag_read_check_dim( 'nobs' )) then
          total_obs = nc_diag_read_get_dim(ftin,'nobs')
-         ncdiag_open_status(nopen_ncdiag)%num_records = total_obs
+         ncdiag_open_status(ii)%num_records = total_obs
       else
          print *, 'ERROR:  unable to read nobs'
          ierr=1
@@ -1048,7 +1060,7 @@ module conmon_read_diag
       call load_nc_var( 'Height',                        ftin, Height,                        ierr )
       call load_nc_var( 'Time',                          ftin, Time,                          ierr )
       call load_nc_var( 'Prep_QC_Mark',                  ftin, Prep_QC_Mark,                  ierr )
-!      call load_nc_var( 'Nonlinear_QC_Var_Jb',           ftin, Nonlinear_QC_Var_Jb,           ierr )
+      call load_nc_var( 'Nonlinear_QC_Var_Jb',           ftin, Nonlinear_QC_Var_Jb,           ierr )
       call load_nc_var( 'Nonlinear_QC_Rel_Wgt',          ftin, Nonlinear_QC_Rel_Wgt,          ierr )
       call load_nc_var( 'Prep_Use_Flag',                 ftin, Prep_Use_Flag,                 ierr )
       call load_nc_var( 'Analysis_Use_Flag',             ftin, Analysis_Use_Flag,             ierr )
@@ -1085,14 +1097,14 @@ module conmon_read_diag
          ! interesting (but not in a good way).
          !
          add_obs = .false.
-         
+
          if( adjustl( trim( Observation_Class(ii) )) == adjustl( trim( ctype ))) then         
 
             if( return_all .eqv. .true. ) then
                add_obs = .true.
 
             else if( Observation_Type(ii) == intype ) then
- 
+
                if( have_subtype .eqv. .false. ) then
                   add_obs = .true.
                else if( Observation_Subtype(ii) == in_subtype ) then
@@ -1106,7 +1118,6 @@ module conmon_read_diag
 
             nobs=nobs+1
 
-            print *, 'Loading new ptr'
             !---------------------------------------------
             ! Allocate a new data element and load
             !
@@ -1142,9 +1153,7 @@ module conmon_read_diag
                if( allocated( Bias_Correction_Terms      )) ptr%p%rdiag( idx_vv_t+jj )       = Bias_Correction_Terms( jj,ii )
             end do
 
-
             if( nobs == 1 ) then
-               print *, 'Initializing  LIST'
                !-------------------------------------------------
                ! Initialize the list with the first data element
                !
@@ -1155,7 +1164,6 @@ module conmon_read_diag
                !-------------------------------------------------
                ! Insert subsequent nodes into the list
                !
-               print *, 'Adding to LIST'
                call list_insert(next, transfer(ptr, list_data))
                next => list_next(next)
 
@@ -1196,20 +1204,21 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for uv data types in netcdf files
    !
-   subroutine read_diag_file_uv_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
+   subroutine read_diag_file_uv_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
   
       !--- interface 
+      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, in_subtype
+      integer, intent(in)        :: intype, expected_nreal, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, total_obs, idx
+      integer                    :: ii, ierr, istatus, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1241,6 +1250,7 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: v_Observation                   !  (obs)
       real(r_single), dimension(:), allocatable    :: v_Obs_Minus_Forecast_adjusted   !  (obs)
       real(r_single), dimension(:), allocatable    :: v_Obs_Minus_Forecast_unadjusted !  (obs)
+      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_uv_nc'
@@ -1425,20 +1435,21 @@ module conmon_read_diag
    !          in binary and NetCDF formatted diag files. See
    !          comments below.
    !
-   subroutine read_diag_file_gps_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
+   subroutine read_diag_file_gps_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
  
       !--- interface 
+      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, in_subtype
+      integer, intent(in)        :: intype, expected_nreal, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, total_obs, idx
+      integer                    :: ii, ierr, istatus, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1451,12 +1462,14 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Latitude                          !  (obs)
       real(r_single), dimension(:), allocatable    :: Longitude                         !  (obs)
       real(r_single), dimension(:), allocatable    :: Incremental_Bending_Angle         !  (obs)
+      real(r_single), dimension(:), allocatable    :: Station_Elevation                 !  (obs)
       real(r_single), dimension(:), allocatable    :: Pressure                          !  (obs)
       real(r_single), dimension(:), allocatable    :: Height                            !  (obs)
       real(r_single), dimension(:), allocatable    :: Time                              !  (obs)
       real(r_single), dimension(:), allocatable    :: Model_Elevation                   !  (obs)
       real(r_single), dimension(:), allocatable    :: Setup_QC_Mark                     !  (obs)
       real(r_single), dimension(:), allocatable    :: Prep_Use_Flag                     !  (obs)
+      real(r_single), dimension(:), allocatable    :: Nonlinear_QC_Var_Jb               !  (obs)
       real(r_single), dimension(:), allocatable    :: Nonlinear_QC_Rel_Wgt              !  (obs)
       real(r_single), dimension(:), allocatable    :: Analysis_Use_Flag                 !  (obs)
       real(r_single), dimension(:), allocatable    :: Errinv_Input                      !  (obs)
@@ -1468,6 +1481,8 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: GPS_Type                          !  (obs)
       real(r_single), dimension(:), allocatable    :: Temperature_at_Obs_Location       !  (obs)
       real(r_single), dimension(:), allocatable    :: Specific_Humidity_at_Obs_Location !  (obs)
+
+      integer(i_kind)                              :: idate 
 
 
 
@@ -1684,9 +1699,11 @@ module conmon_read_diag
       character(8),allocatable,dimension(:)  :: cdiag 
 
       character(3)   :: dtype
+      character(10)  :: otype
+      character(15)  :: fileo,fileo_subtyp
 
-      integer nchar,file_nreal,i,ii,mype,idate,iflag,file_itype
-      integer lunin,file_subtype
+      integer nchar,file_nreal,i,ii,mype,idate,iflag,file_itype,iscater,igrads
+      integer lunin,lunot,ldtype,file_subtype
       integer idx,ioff02
 
       data lunin / 11 /

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfc.fd/conmon_read_diag.F90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfc.fd/conmon_read_diag.F90
@@ -159,7 +159,7 @@ module conmon_read_diag
 
       if ( netcdf ) then
          write(6,*) ' call nc read subroutine'
-         call read_diag_file_nc( input_file, return_all, ctype, intype, expected_nreal, nobs, in_subtype, list )
+         call read_diag_file_nc( input_file, return_all, ctype, intype, nobs, in_subtype, list )
       else
          call read_diag_file_bin( input_file,return_all, ctype, intype, expected_nreal,nobs,in_subtype, list )
       end if
@@ -205,7 +205,7 @@ module conmon_read_diag
       !
       if ( netcdf ) then
          write(6,*) ' call nc retrieve all routine'
-         call read_diag_file_nc( input_file, return_all, ctype, intype, expected_nreal, nobs, in_subtype, list )
+         call read_diag_file_nc( input_file, return_all, ctype, intype, nobs, in_subtype, list )
       else
          write(6,*) ' call bin retrieve all routine'
          call read_diag_file_bin( input_file,return_all, ctype, intype, expected_nreal,nobs,in_subtype, list )
@@ -221,20 +221,18 @@ module conmon_read_diag
    !
    !  NetCDF read routine
    !-------------------------------
-   subroutine read_diag_file_nc( input_file, return_all, ctype, intype, expected_nreal, nobs, in_subtype, list )
+   subroutine read_diag_file_nc( input_file, return_all, ctype, intype, nobs, in_subtype, list )
 
       !--- interface 
       character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
-      type(list_node_t), pointer :: next => null()
-      type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, ftin, total_obs, id, idx
+      integer                    :: ii, ierr, ftin, id
 
       data ftin / 11 /
 
@@ -251,7 +249,7 @@ module conmon_read_diag
       endif
 
       call nc_diag_read_init( input_file, ftin )
-      istatus=0
+      print *, '  ftin: ', ftin
 
       do ii = 1, MAX_OPEN_NCDIAG
 
@@ -270,22 +268,22 @@ module conmon_read_diag
       select case ( trim( adjustl( ctype ) ) )
    
          case ( 'gps' ) 
-            call read_diag_file_gps_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_gps_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 'ps' ) 
-            call read_diag_file_ps_nc(  input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_ps_nc(  return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 'q' ) 
-            call read_diag_file_q_nc(   input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_q_nc(   return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 'sst' )
-            call read_diag_file_sst_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_sst_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 't' ) 
-            call read_diag_file_t_nc(   input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_t_nc(   return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 'uv' ) 
-            call read_diag_file_uv_nc(  input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_uv_nc(  return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case default
             print *, 'ERROR:  unmatched ctype :', ctype
@@ -318,21 +316,20 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for ps data types in netcdf files
    !
-   subroutine read_diag_file_ps_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
+   subroutine read_diag_file_ps_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -359,7 +356,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Observation                     !  (obs)
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_adjusted     !  (obs)
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_unadjusted   !  (obs)
-      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_ps_nc'
@@ -521,21 +517,20 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for q data types in netcdf files
    !
-   subroutine read_diag_file_q_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
+   subroutine read_diag_file_q_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -563,7 +558,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_adjusted     !  (obs)
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_unadjusted   !  (obs)
       real(r_single), dimension(:), allocatable    :: Forecast_Saturation_Spec_Hum    !  (obs)
-      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_q_nc'
@@ -736,21 +730,20 @@ module conmon_read_diag
    !  NOTE2:  There are known discrepencies between the contents
    !          of sst obs in binary and NetCDF files. 
    !
-   subroutine read_diag_file_sst_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
+   subroutine read_diag_file_sst_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -781,7 +774,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: DiurnalWarming_at_zob           !  (obs)
       real(r_single), dimension(:), allocatable    :: SkinLayerCooling_at_zob         !  (obs)
       real(r_single), dimension(:), allocatable    :: Sensitivity_Tzob_Tr             !  (obs)
-      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_sst_nc'
@@ -966,21 +958,20 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for t data types in netcdf files
    !
-   subroutine read_diag_file_t_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+   subroutine read_diag_file_t_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx, bcor_terms
+      integer                    :: ii, ierr, total_obs, idx, bcor_terms
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1010,25 +1001,22 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Data_Pof                        !  (obs) 
       real(r_single), dimension(:), allocatable    :: Data_Vertical_Velocity          !  (obs)
       real(r_single), dimension(:,:), allocatable  :: Bias_Correction_Terms           !  (nobs, Bias_Correction_Terms_arr_dim)
-      integer(i_kind)                              :: idate 
       integer(i_kind)                              :: jj
 
       print *, ' '
       print *, '      --> read_diag_file_t_nc'
 
-      print *, '            input_file = ', input_file
+      print *, '            return_all = ', return_all
       print *, '            ftin       = ', ftin
       print *, '            ctype      = ', ctype
       print *, '            intype     = ', intype  
-      print *, '            expected_nreal = ', expected_nreal 
       print *, '            in_subtype = ', in_subtype
-
 
       !--- get NetCDF file dimensions
       !
       if( nc_diag_read_check_dim( 'nobs' )) then
          total_obs = nc_diag_read_get_dim(ftin,'nobs')
-         ncdiag_open_status(ii)%num_records = total_obs
+         ncdiag_open_status(nopen_ncdiag)%num_records = total_obs
       else
          print *, 'ERROR:  unable to read nobs'
          ierr=1
@@ -1060,7 +1048,7 @@ module conmon_read_diag
       call load_nc_var( 'Height',                        ftin, Height,                        ierr )
       call load_nc_var( 'Time',                          ftin, Time,                          ierr )
       call load_nc_var( 'Prep_QC_Mark',                  ftin, Prep_QC_Mark,                  ierr )
-      call load_nc_var( 'Nonlinear_QC_Var_Jb',           ftin, Nonlinear_QC_Var_Jb,           ierr )
+!      call load_nc_var( 'Nonlinear_QC_Var_Jb',           ftin, Nonlinear_QC_Var_Jb,           ierr )
       call load_nc_var( 'Nonlinear_QC_Rel_Wgt',          ftin, Nonlinear_QC_Rel_Wgt,          ierr )
       call load_nc_var( 'Prep_Use_Flag',                 ftin, Prep_Use_Flag,                 ierr )
       call load_nc_var( 'Analysis_Use_Flag',             ftin, Analysis_Use_Flag,             ierr )
@@ -1097,14 +1085,14 @@ module conmon_read_diag
          ! interesting (but not in a good way).
          !
          add_obs = .false.
-
+         
          if( adjustl( trim( Observation_Class(ii) )) == adjustl( trim( ctype ))) then         
 
             if( return_all .eqv. .true. ) then
                add_obs = .true.
 
             else if( Observation_Type(ii) == intype ) then
-
+ 
                if( have_subtype .eqv. .false. ) then
                   add_obs = .true.
                else if( Observation_Subtype(ii) == in_subtype ) then
@@ -1118,6 +1106,7 @@ module conmon_read_diag
 
             nobs=nobs+1
 
+            print *, 'Loading new ptr'
             !---------------------------------------------
             ! Allocate a new data element and load
             !
@@ -1153,7 +1142,9 @@ module conmon_read_diag
                if( allocated( Bias_Correction_Terms      )) ptr%p%rdiag( idx_vv_t+jj )       = Bias_Correction_Terms( jj,ii )
             end do
 
+
             if( nobs == 1 ) then
+               print *, 'Initializing  LIST'
                !-------------------------------------------------
                ! Initialize the list with the first data element
                !
@@ -1164,6 +1155,7 @@ module conmon_read_diag
                !-------------------------------------------------
                ! Insert subsequent nodes into the list
                !
+               print *, 'Adding to LIST'
                call list_insert(next, transfer(ptr, list_data))
                next => list_next(next)
 
@@ -1204,21 +1196,20 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for uv data types in netcdf files
    !
-   subroutine read_diag_file_uv_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+   subroutine read_diag_file_uv_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1250,7 +1241,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: v_Observation                   !  (obs)
       real(r_single), dimension(:), allocatable    :: v_Obs_Minus_Forecast_adjusted   !  (obs)
       real(r_single), dimension(:), allocatable    :: v_Obs_Minus_Forecast_unadjusted !  (obs)
-      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_uv_nc'
@@ -1435,21 +1425,20 @@ module conmon_read_diag
    !          in binary and NetCDF formatted diag files. See
    !          comments below.
    !
-   subroutine read_diag_file_gps_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
+   subroutine read_diag_file_gps_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
  
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1462,14 +1451,12 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Latitude                          !  (obs)
       real(r_single), dimension(:), allocatable    :: Longitude                         !  (obs)
       real(r_single), dimension(:), allocatable    :: Incremental_Bending_Angle         !  (obs)
-      real(r_single), dimension(:), allocatable    :: Station_Elevation                 !  (obs)
       real(r_single), dimension(:), allocatable    :: Pressure                          !  (obs)
       real(r_single), dimension(:), allocatable    :: Height                            !  (obs)
       real(r_single), dimension(:), allocatable    :: Time                              !  (obs)
       real(r_single), dimension(:), allocatable    :: Model_Elevation                   !  (obs)
       real(r_single), dimension(:), allocatable    :: Setup_QC_Mark                     !  (obs)
       real(r_single), dimension(:), allocatable    :: Prep_Use_Flag                     !  (obs)
-      real(r_single), dimension(:), allocatable    :: Nonlinear_QC_Var_Jb               !  (obs)
       real(r_single), dimension(:), allocatable    :: Nonlinear_QC_Rel_Wgt              !  (obs)
       real(r_single), dimension(:), allocatable    :: Analysis_Use_Flag                 !  (obs)
       real(r_single), dimension(:), allocatable    :: Errinv_Input                      !  (obs)
@@ -1481,8 +1468,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: GPS_Type                          !  (obs)
       real(r_single), dimension(:), allocatable    :: Temperature_at_Obs_Location       !  (obs)
       real(r_single), dimension(:), allocatable    :: Specific_Humidity_at_Obs_Location !  (obs)
-
-      integer(i_kind)                              :: idate 
 
 
 
@@ -1699,11 +1684,9 @@ module conmon_read_diag
       character(8),allocatable,dimension(:)  :: cdiag 
 
       character(3)   :: dtype
-      character(10)  :: otype
-      character(15)  :: fileo,fileo_subtyp
 
-      integer nchar,file_nreal,i,ii,mype,idate,iflag,file_itype,iscater,igrads
-      integer lunin,lunot,ldtype,file_subtype
+      integer nchar,file_nreal,i,ii,mype,idate,iflag,file_itype
+      integer lunin,file_subtype
       integer idx,ioff02
 
       data lunin / 11 /

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfc.fd/conmon_read_diag.F90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfc.fd/conmon_read_diag.F90
@@ -232,9 +232,7 @@ module conmon_read_diag
       type(list_node_t), pointer :: list
 
       !--- local vars
-      type(list_node_t), pointer :: next => null()
-      type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, ftin, total_obs, id, idx
+      integer                    :: ii, ierr, ftin, id
 
       data ftin / 11 /
 
@@ -251,7 +249,6 @@ module conmon_read_diag
       endif
 
       call nc_diag_read_init( input_file, ftin )
-      istatus=0
 
       do ii = 1, MAX_OPEN_NCDIAG
 
@@ -332,7 +329,7 @@ module conmon_read_diag
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -359,7 +356,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Observation                     !  (obs)
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_adjusted     !  (obs)
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_unadjusted   !  (obs)
-      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_ps_nc'
@@ -535,7 +531,7 @@ module conmon_read_diag
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -563,7 +559,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_adjusted     !  (obs)
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_unadjusted   !  (obs)
       real(r_single), dimension(:), allocatable    :: Forecast_Saturation_Spec_Hum    !  (obs)
-      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_q_nc'
@@ -750,7 +745,7 @@ module conmon_read_diag
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -781,7 +776,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: DiurnalWarming_at_zob           !  (obs)
       real(r_single), dimension(:), allocatable    :: SkinLayerCooling_at_zob         !  (obs)
       real(r_single), dimension(:), allocatable    :: Sensitivity_Tzob_Tr             !  (obs)
-      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_sst_nc'
@@ -980,7 +974,7 @@ module conmon_read_diag
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx, bcor_terms
+      integer                    :: ii, ierr, total_obs, idx, bcor_terms
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1010,7 +1004,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Data_Pof                        !  (obs) 
       real(r_single), dimension(:), allocatable    :: Data_Vertical_Velocity          !  (obs)
       real(r_single), dimension(:,:), allocatable  :: Bias_Correction_Terms           !  (nobs, Bias_Correction_Terms_arr_dim)
-      integer(i_kind)                              :: idate 
       integer(i_kind)                              :: jj
 
       print *, ' '
@@ -1218,7 +1211,7 @@ module conmon_read_diag
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1250,7 +1243,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: v_Observation                   !  (obs)
       real(r_single), dimension(:), allocatable    :: v_Obs_Minus_Forecast_adjusted   !  (obs)
       real(r_single), dimension(:), allocatable    :: v_Obs_Minus_Forecast_unadjusted !  (obs)
-      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_uv_nc'
@@ -1449,7 +1441,7 @@ module conmon_read_diag
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1481,9 +1473,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: GPS_Type                          !  (obs)
       real(r_single), dimension(:), allocatable    :: Temperature_at_Obs_Location       !  (obs)
       real(r_single), dimension(:), allocatable    :: Specific_Humidity_at_Obs_Location !  (obs)
-
-      integer(i_kind)                              :: idate 
-
 
 
       print *, ' '
@@ -1699,11 +1688,9 @@ module conmon_read_diag
       character(8),allocatable,dimension(:)  :: cdiag 
 
       character(3)   :: dtype
-      character(10)  :: otype
-      character(15)  :: fileo,fileo_subtyp
 
-      integer nchar,file_nreal,i,ii,mype,idate,iflag,file_itype,iscater,igrads
-      integer lunin,lunot,ldtype,file_subtype
+      integer nchar,file_nreal,i,ii,mype,idate,iflag,file_itype
+      integer lunin,file_subtype
       integer idx,ioff02
 
       data lunin / 11 /

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfc.fd/grads_sfc.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfc.fd/grads_sfc.f90
@@ -12,6 +12,8 @@ subroutine grads_sfc(fileo,ifileo,nobs,nreal,iscater,igrads,isubtype,subtype,lis
 
    implicit none
 
+   external :: rm_dups
+
    type(list_node_t), pointer   :: list
    type(list_node_t), pointer   :: next => null()
    type(data_ptr)               :: ptr
@@ -23,7 +25,7 @@ subroutine grads_sfc(fileo,ifileo,nobs,nreal,iscater,igrads,isubtype,subtype,lis
    character(ifileo) :: fileo
    character(30) :: files,filein,filegrads, file_nobs
    character(3) :: subtype,run
-   integer nobs,nreal,nlfag,nflg0,nlev,nlev0,iscater,igrads
+   integer nobs,nreal,nflg0,nlev0,iscater,igrads
    real(4) rtim,xlat0,xlon0,rlat,rlon
  
    integer(4):: isubtype

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfc.fd/grads_sfc.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfc.fd/grads_sfc.f90
@@ -5,14 +5,12 @@
 !       horizontal GrADS data files.
 !------------------------------------------------------------------------
 
-subroutine grads_sfc(fileo,ifileo,nobs,nreal,iscater,igrads,subtype,list,run)
+subroutine grads_sfc(fileo,ifileo,nobs,nreal,iscater,igrads,isubtype,subtype,list,run)
 
    use generic_list
    use data
 
    implicit none
-
-   external ::  rm_dups
 
    type(list_node_t), pointer   :: list
    type(list_node_t), pointer   :: next => null()
@@ -25,9 +23,10 @@ subroutine grads_sfc(fileo,ifileo,nobs,nreal,iscater,igrads,subtype,list,run)
    character(ifileo) :: fileo
    character(30) :: files,filein,filegrads, file_nobs
    character(3) :: subtype,run
-   integer nobs,nreal,nflg0,nlev0,iscater,igrads
+   integer nobs,nreal,nlfag,nflg0,nlev,nlev0,iscater,igrads
    real(4) rtim,xlat0,xlon0,rlat,rlon
  
+   integer(4):: isubtype
    integer i,j,ilat,ilon,ipres,itime,iweight,ndup
 
    rtim=0.0
@@ -67,6 +66,8 @@ subroutine grads_sfc(fileo,ifileo,nobs,nreal,iscater,igrads,subtype,list,run)
          rdiag_m2(i-2, obs_ctr) = ptr%p%rdiag( i )
       end do
    end do
+
+   print *, 'obs_ctr (list) = ', obs_ctr
 
 
    !-------------------------------

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfc.fd/grads_sfc.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfc.fd/grads_sfc.f90
@@ -5,12 +5,14 @@
 !       horizontal GrADS data files.
 !------------------------------------------------------------------------
 
-subroutine grads_sfc(fileo,ifileo,nobs,nreal,iscater,igrads,isubtype,subtype,list,run)
+subroutine grads_sfc(fileo,ifileo,nobs,nreal,iscater,igrads,subtype,list,run)
 
    use generic_list
    use data
 
    implicit none
+
+   external ::  rm_dups
 
    type(list_node_t), pointer   :: list
    type(list_node_t), pointer   :: next => null()
@@ -23,10 +25,9 @@ subroutine grads_sfc(fileo,ifileo,nobs,nreal,iscater,igrads,isubtype,subtype,lis
    character(ifileo) :: fileo
    character(30) :: files,filein,filegrads, file_nobs
    character(3) :: subtype,run
-   integer nobs,nreal,nlfag,nflg0,nlev,nlev0,iscater,igrads
+   integer nobs,nreal,nflg0,nlev0,iscater,igrads
    real(4) rtim,xlat0,xlon0,rlat,rlon
  
-   integer(4):: isubtype
    integer i,j,ilat,ilon,ipres,itime,iweight,ndup
 
    rtim=0.0
@@ -66,8 +67,6 @@ subroutine grads_sfc(fileo,ifileo,nobs,nreal,iscater,igrads,isubtype,subtype,lis
          rdiag_m2(i-2, obs_ctr) = ptr%p%rdiag( i )
       end do
    end do
-
-   print *, 'obs_ctr (list) = ', obs_ctr
 
 
    !-------------------------------

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfc.fd/maingrads_sfc.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfc.fd/maingrads_sfc.f90
@@ -29,27 +29,20 @@ program maingrads_sfc
 
    end interface
 
-   real(4),dimension(21) :: pmand 
-   character(10) :: fileo,stype 
+   character(10) :: stype 
    character(3) :: intype
    character(3) :: subtype
-   integer nreal,nreal_m2,iscater,igrads,isubtype 
-   integer n_alllev,n_acft,n_lowlev,n_upair,nobs,lstype
-   integer n_mand,itype
+   integer nreal,iscater,igrads,isubtype 
+   integer nobs,lstype
+   integer itype
 
    type(list_node_t), pointer   :: list => null()
-   type(list_node_t), pointer   :: next => null()
-   type(data_ptr)               :: ptr
 
    !--- namelist with defaults
    logical               :: netcdf              = .false.
    character(100)        :: input_file          = "conv_diag"
    character(3)          :: run                 = "ges"
    namelist /input/input_file,intype,stype,itype,nreal,iscater,igrads,subtype,isubtype,netcdf,run
-
-   data n_mand / 21 /
-   data pmand /1000.,925.,850.,700.,500.,400.,300.,250.,200.,150.,100.,&
-               70.,50.,30.,20.,10.,7.,5.,3.,2.,1./
 
    read(5,input)
    write(6,*)' User input below'
@@ -61,7 +54,7 @@ program maingrads_sfc
    call set_netcdf_read( netcdf )
 
    call conmon_read_diag_file( input_file, intype, itype, nreal, nobs, isubtype, list )
-
+   print *, 'nobs read = ', nobs
  
    if( nobs > 0 ) then
       call grads_sfc(stype,lstype,nobs,nreal,iscater,igrads,isubtype,subtype,list,run) 

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfc.fd/maingrads_sfc.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfc.fd/maingrads_sfc.f90
@@ -29,27 +29,20 @@ program maingrads_sfc
 
    end interface
 
-   real(4),dimension(21) :: pmand 
-   character(10) :: fileo,stype 
+   character(10) :: stype 
    character(3) :: intype
    character(3) :: subtype
-   integer nreal,nreal_m2,iscater,igrads,isubtype 
-   integer n_alllev,n_acft,n_lowlev,n_upair,nobs,lstype
-   integer n_mand,itype
+   integer nreal,iscater,igrads,isubtype 
+   integer nobs,lstype
+   integer itype
 
    type(list_node_t), pointer   :: list => null()
-   type(list_node_t), pointer   :: next => null()
-   type(data_ptr)               :: ptr
 
    !--- namelist with defaults
    logical               :: netcdf              = .false.
    character(100)        :: input_file          = "conv_diag"
    character(3)          :: run                 = "ges"
    namelist /input/input_file,intype,stype,itype,nreal,iscater,igrads,subtype,isubtype,netcdf,run
-
-   data n_mand / 21 /
-   data pmand /1000.,925.,850.,700.,500.,400.,300.,250.,200.,150.,100.,&
-               70.,50.,30.,20.,10.,7.,5.,3.,2.,1./
 
    read(5,input)
    write(6,*)' User input below'

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfc.fd/maingrads_sfc.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfc.fd/maingrads_sfc.f90
@@ -29,20 +29,27 @@ program maingrads_sfc
 
    end interface
 
-   character(10) :: stype 
+   real(4),dimension(21) :: pmand 
+   character(10) :: fileo,stype 
    character(3) :: intype
    character(3) :: subtype
-   integer nreal,iscater,igrads,isubtype 
-   integer nobs,lstype
-   integer itype
+   integer nreal,nreal_m2,iscater,igrads,isubtype 
+   integer n_alllev,n_acft,n_lowlev,n_upair,nobs,lstype
+   integer n_mand,itype
 
    type(list_node_t), pointer   :: list => null()
+   type(list_node_t), pointer   :: next => null()
+   type(data_ptr)               :: ptr
 
    !--- namelist with defaults
    logical               :: netcdf              = .false.
    character(100)        :: input_file          = "conv_diag"
    character(3)          :: run                 = "ges"
    namelist /input/input_file,intype,stype,itype,nreal,iscater,igrads,subtype,isubtype,netcdf,run
+
+   data n_mand / 21 /
+   data pmand /1000.,925.,850.,700.,500.,400.,300.,250.,200.,150.,100.,&
+               70.,50.,30.,20.,10.,7.,5.,3.,2.,1./
 
    read(5,input)
    write(6,*)' User input below'
@@ -54,7 +61,7 @@ program maingrads_sfc
    call set_netcdf_read( netcdf )
 
    call conmon_read_diag_file( input_file, intype, itype, nreal, nobs, isubtype, list )
-   print *, 'nobs read = ', nobs
+
  
    if( nobs > 0 ) then
       call grads_sfc(stype,lstype,nobs,nreal,iscater,igrads,isubtype,subtype,list,run) 

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfctime.fd/conmon_read_diag.F90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfctime.fd/conmon_read_diag.F90
@@ -232,9 +232,7 @@ module conmon_read_diag
       type(list_node_t), pointer :: list
 
       !--- local vars
-      type(list_node_t), pointer :: next => null()
-      type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, ftin, total_obs, id, idx
+      integer                    :: ii, ierr, ftin, id
 
       data ftin / 11 /
 
@@ -251,7 +249,6 @@ module conmon_read_diag
       endif
 
       call nc_diag_read_init( input_file, ftin )
-      istatus=0
 
       do ii = 1, MAX_OPEN_NCDIAG
 
@@ -332,7 +329,7 @@ module conmon_read_diag
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -359,7 +356,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Observation                     !  (obs)
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_adjusted     !  (obs)
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_unadjusted   !  (obs)
-      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_ps_nc'
@@ -535,7 +531,7 @@ module conmon_read_diag
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -563,7 +559,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_adjusted     !  (obs)
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_unadjusted   !  (obs)
       real(r_single), dimension(:), allocatable    :: Forecast_Saturation_Spec_Hum    !  (obs)
-      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_q_nc'
@@ -750,7 +745,7 @@ module conmon_read_diag
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -781,7 +776,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: DiurnalWarming_at_zob           !  (obs)
       real(r_single), dimension(:), allocatable    :: SkinLayerCooling_at_zob         !  (obs)
       real(r_single), dimension(:), allocatable    :: Sensitivity_Tzob_Tr             !  (obs)
-      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_sst_nc'
@@ -980,7 +974,7 @@ module conmon_read_diag
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx, bcor_terms
+      integer                    :: ii, ierr, total_obs, idx, bcor_terms
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1010,7 +1004,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Data_Pof                        !  (obs) 
       real(r_single), dimension(:), allocatable    :: Data_Vertical_Velocity          !  (obs)
       real(r_single), dimension(:,:), allocatable  :: Bias_Correction_Terms           !  (nobs, Bias_Correction_Terms_arr_dim)
-      integer(i_kind)                              :: idate 
       integer(i_kind)                              :: jj
 
       print *, ' '
@@ -1218,7 +1211,7 @@ module conmon_read_diag
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1250,7 +1243,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: v_Observation                   !  (obs)
       real(r_single), dimension(:), allocatable    :: v_Obs_Minus_Forecast_adjusted   !  (obs)
       real(r_single), dimension(:), allocatable    :: v_Obs_Minus_Forecast_unadjusted !  (obs)
-      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_uv_nc'
@@ -1449,7 +1441,7 @@ module conmon_read_diag
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1481,8 +1473,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: GPS_Type                          !  (obs)
       real(r_single), dimension(:), allocatable    :: Temperature_at_Obs_Location       !  (obs)
       real(r_single), dimension(:), allocatable    :: Specific_Humidity_at_Obs_Location !  (obs)
-
-      integer(i_kind)                              :: idate 
 
 
 
@@ -1700,10 +1690,9 @@ module conmon_read_diag
 
       character(3)   :: dtype
       character(10)  :: otype
-      character(15)  :: fileo,fileo_subtyp
 
-      integer nchar,file_nreal,i,ii,mype,idate,iflag,file_itype,iscater,igrads
-      integer lunin,lunot,ldtype,file_subtype
+      integer nchar,file_nreal,i,ii,mype,idate,iflag,file_itype
+      integer lunin,file_subtype
       integer idx,ioff02
 
       data lunin / 11 /

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfctime.fd/grads_sfctime.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfctime.fd/grads_sfctime.f90
@@ -13,7 +13,9 @@ subroutine grads_sfctime(fileo,ifileo,nobs,nreal,nlev,plev,iscater,&
    use data
 
    implicit none
- 
+
+   external ::  rm_dups
+
    type(list_node_t), pointer   :: list
    type(list_node_t), pointer   :: next => null()
    type(data_ptr)               :: ptr
@@ -53,10 +55,9 @@ subroutine grads_sfctime(fileo,ifileo,nobs,nreal,nlev,plev,iscater,&
    character(8),allocatable,dimension(:) :: stid
 
    character(8) :: stidend
-   character(30) :: files,filein,filegrads, file_nobs
-   integer :: nlfag,nflag0,nlev0,getlev
+   character(30) :: files,filegrads, file_nobs
+   integer :: nflag0,nlev0,getlev
    real(4) :: rmiss,rtim,xlat0,xlon0,rtime
-   integer      :: first, second
  
    integer nt,k,i,ii,j,nflag,obs_ctr
    integer ilat,ilon,ipres,itime,iweight,ndup

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfctime.fd/maingrads_sfctime.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfctime.fd/maingrads_sfctime.f90
@@ -34,12 +34,10 @@ program maingrads_sfctime
 
 
    type(list_node_t), pointer   :: list => null()
-   type(list_node_t), pointer   :: next => null()
-   type(data_ptr)               :: ptr
 
    real(4),dimension(11) :: ptime11 
    real(4),dimension(7) :: ptime7
-   character(10) :: fileo,stype,timecard 
+   character(10) :: stype,timecard 
    character(3) :: intype
    character(3) :: subtype
    integer nreal,iscater,igrads,isubtype 

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sig.fd/conmon_read_diag.F90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sig.fd/conmon_read_diag.F90
@@ -158,10 +158,9 @@ module conmon_read_diag
       write(6,*)'--> conmon_read_diag_file'
 
       if ( netcdf ) then
-         write(6,*) ' call nc read subroutine'
-         call read_diag_file_nc( input_file, return_all, ctype, intype, expected_nreal, nobs, in_subtype, list )
+         call read_diag_file_nc(  input_file, return_all, ctype, intype, nobs, in_subtype, list )
       else
-         call read_diag_file_bin( input_file,return_all, ctype, intype, expected_nreal,nobs,in_subtype, list )
+         call read_diag_file_bin( input_file, return_all, ctype, intype, expected_nreal, nobs,in_subtype, list )
       end if
 
       write(6,*)"<-- conmon_read_diag_file"
@@ -205,7 +204,7 @@ module conmon_read_diag
       !
       if ( netcdf ) then
          write(6,*) ' call nc retrieve all routine'
-         call read_diag_file_nc( input_file, return_all, ctype, intype, expected_nreal, nobs, in_subtype, list )
+         call read_diag_file_nc( input_file, return_all, ctype, intype, nobs, in_subtype, list )
       else
          write(6,*) ' call bin retrieve all routine'
          call read_diag_file_bin( input_file,return_all, ctype, intype, expected_nreal,nobs,in_subtype, list )
@@ -221,20 +220,18 @@ module conmon_read_diag
    !
    !  NetCDF read routine
    !-------------------------------
-   subroutine read_diag_file_nc( input_file, return_all, ctype, intype, expected_nreal, nobs, in_subtype, list )
+   subroutine read_diag_file_nc( input_file, return_all, ctype, intype, nobs, in_subtype, list )
 
       !--- interface 
       character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
-      type(list_node_t), pointer :: next => null()
-      type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, ftin, total_obs, id, idx
+      integer                    :: ii, ierr, istatus, ftin, id
 
       data ftin / 11 /
 
@@ -270,22 +267,22 @@ module conmon_read_diag
       select case ( trim( adjustl( ctype ) ) )
    
          case ( 'gps' ) 
-            call read_diag_file_gps_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_gps_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 'ps' ) 
-            call read_diag_file_ps_nc(  input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_ps_nc(  return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 'q' ) 
-            call read_diag_file_q_nc(   input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_q_nc(   return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 'sst' )
-            call read_diag_file_sst_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_sst_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 't' ) 
-            call read_diag_file_t_nc(   input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_t_nc(   return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 'uv' ) 
-            call read_diag_file_uv_nc(  input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_uv_nc(  return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case default
             print *, 'ERROR:  unmatched ctype :', ctype
@@ -318,21 +315,20 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for ps data types in netcdf files
    !
-   subroutine read_diag_file_ps_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
+   subroutine read_diag_file_ps_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -359,7 +355,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Observation                     !  (obs)
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_adjusted     !  (obs)
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_unadjusted   !  (obs)
-      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_ps_nc'
@@ -521,21 +516,20 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for q data types in netcdf files
    !
-   subroutine read_diag_file_q_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
+   subroutine read_diag_file_q_nc( return_all, ftin, ctype, intype,nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -563,7 +557,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_adjusted     !  (obs)
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_unadjusted   !  (obs)
       real(r_single), dimension(:), allocatable    :: Forecast_Saturation_Spec_Hum    !  (obs)
-      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_q_nc'
@@ -736,21 +729,20 @@ module conmon_read_diag
    !  NOTE2:  There are known discrepencies between the contents
    !          of sst obs in binary and NetCDF files. 
    !
-   subroutine read_diag_file_sst_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
+   subroutine read_diag_file_sst_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -781,7 +773,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: DiurnalWarming_at_zob           !  (obs)
       real(r_single), dimension(:), allocatable    :: SkinLayerCooling_at_zob         !  (obs)
       real(r_single), dimension(:), allocatable    :: Sensitivity_Tzob_Tr             !  (obs)
-      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_sst_nc'
@@ -966,21 +957,20 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for t data types in netcdf files
    !
-   subroutine read_diag_file_t_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+   subroutine read_diag_file_t_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx, bcor_terms
+      integer                    :: ii, ierr, total_obs, idx, bcor_terms
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1010,17 +1000,14 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Data_Pof                        !  (obs) 
       real(r_single), dimension(:), allocatable    :: Data_Vertical_Velocity          !  (obs)
       real(r_single), dimension(:,:), allocatable  :: Bias_Correction_Terms           !  (nobs, Bias_Correction_Terms_arr_dim)
-      integer(i_kind)                              :: idate 
       integer(i_kind)                              :: jj
 
       print *, ' '
       print *, '      --> read_diag_file_t_nc'
 
-      print *, '            input_file = ', input_file
       print *, '            ftin       = ', ftin
       print *, '            ctype      = ', ctype
       print *, '            intype     = ', intype  
-      print *, '            expected_nreal = ', expected_nreal 
       print *, '            in_subtype = ', in_subtype
 
 
@@ -1204,21 +1191,20 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for uv data types in netcdf files
    !
-   subroutine read_diag_file_uv_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+   subroutine read_diag_file_uv_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1250,7 +1236,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: v_Observation                   !  (obs)
       real(r_single), dimension(:), allocatable    :: v_Obs_Minus_Forecast_adjusted   !  (obs)
       real(r_single), dimension(:), allocatable    :: v_Obs_Minus_Forecast_unadjusted !  (obs)
-      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_uv_nc'
@@ -1435,21 +1420,20 @@ module conmon_read_diag
    !          in binary and NetCDF formatted diag files. See
    !          comments below.
    !
-   subroutine read_diag_file_gps_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
+   subroutine read_diag_file_gps_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
  
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1462,14 +1446,12 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Latitude                          !  (obs)
       real(r_single), dimension(:), allocatable    :: Longitude                         !  (obs)
       real(r_single), dimension(:), allocatable    :: Incremental_Bending_Angle         !  (obs)
-      real(r_single), dimension(:), allocatable    :: Station_Elevation                 !  (obs)
       real(r_single), dimension(:), allocatable    :: Pressure                          !  (obs)
       real(r_single), dimension(:), allocatable    :: Height                            !  (obs)
       real(r_single), dimension(:), allocatable    :: Time                              !  (obs)
       real(r_single), dimension(:), allocatable    :: Model_Elevation                   !  (obs)
       real(r_single), dimension(:), allocatable    :: Setup_QC_Mark                     !  (obs)
       real(r_single), dimension(:), allocatable    :: Prep_Use_Flag                     !  (obs)
-      real(r_single), dimension(:), allocatable    :: Nonlinear_QC_Var_Jb               !  (obs)
       real(r_single), dimension(:), allocatable    :: Nonlinear_QC_Rel_Wgt              !  (obs)
       real(r_single), dimension(:), allocatable    :: Analysis_Use_Flag                 !  (obs)
       real(r_single), dimension(:), allocatable    :: Errinv_Input                      !  (obs)
@@ -1481,8 +1463,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: GPS_Type                          !  (obs)
       real(r_single), dimension(:), allocatable    :: Temperature_at_Obs_Location       !  (obs)
       real(r_single), dimension(:), allocatable    :: Specific_Humidity_at_Obs_Location !  (obs)
-
-      integer(i_kind)                              :: idate 
 
 
 
@@ -1699,11 +1679,9 @@ module conmon_read_diag
       character(8),allocatable,dimension(:)  :: cdiag 
 
       character(3)   :: dtype
-      character(10)  :: otype
-      character(15)  :: fileo,fileo_subtyp
 
-      integer nchar,file_nreal,i,ii,mype,idate,iflag,file_itype,iscater,igrads
-      integer lunin,lunot,ldtype,file_subtype
+      integer nchar,file_nreal,i,ii,mype,idate,iflag,file_itype
+      integer lunin,file_subtype
       integer idx,ioff02
 
       data lunin / 11 /

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sig.fd/grads_sig.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sig.fd/grads_sig.f90
@@ -12,6 +12,8 @@ subroutine grads_sig(fileo,ifileo,nobs,nreal,nlev,plev,iscater,igrads,isubtype,s
 
    implicit none
 
+   external ::  rm_dups
+
    type(list_node_t), pointer   :: list
    type(list_node_t), pointer   :: next => null()
    type(data_ptr)               :: ptr 
@@ -27,10 +29,10 @@ subroutine grads_sig(fileo,ifileo,nobs,nreal,nlev,plev,iscater,igrads,isubtype,s
    character(ifileo) :: fileo
    character(30) :: files,filegrads, file_nobs
 
-   integer :: nobs,nreal,nlfag,nflag0,nlev,nlev0,getpro,iscater,igrads,obs_ctr
+   integer :: nobs,nreal,nflag0,nlev,nlev0,getpro,iscater,igrads,obs_ctr
    real(4) :: rtim,xlat0,xlon0
    integer(4):: isubtype,ctr,nreal_m2
-   integer i,j,k,ilat,ilon,ipres,itime,iweight,ndup,nflag
+   integer i,k,ilat,ilon,ipres,itime,iweight,ndup,nflag
  
 
    stdid='        '

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sig.fd/maingrads_sig.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sig.fd/maingrads_sig.f90
@@ -34,16 +34,14 @@ program maingrads_sig
 
 
    real(4),dimension(46) :: psig 
-   character(10) :: fileo,stype,time
+   character(10) :: stype,time
    character(3) :: intype
    character(3) :: subtype
-   integer nreal,nreal_m2,iscater,igrads,isubtype 
-   integer n_alllev,n_acft,n_lowlev,n_upair,nobs,lstype
-   integer itype,n_sig,ii
+   integer nreal,iscater,igrads,isubtype
+   integer nobs,lstype
+   integer itype,n_sig
 
-   type(list_node_t), pointer   :: list => null() 
-   type(list_node_t), pointer   :: next => null() 
-   type(data_ptr)               :: ptr
+   type(list_node_t), pointer   :: list => null()
 
 
    !--- namelist with defaults

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sig.fd/read_conv2grads.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sig.fd/read_conv2grads.f90
@@ -13,7 +13,7 @@
 !        stype   : the observation sub type, like t120 uv220
 !----------------------------------------------------------------------
 
-subroutine read_conv2grads(ctype,stype,intype,target_nreal,nobs,isubtype,subtype,list)
+subroutine read_conv2grads(ctype,intype,target_nreal,nobs,isubtype,list)
 
    use generic_list
    use data
@@ -28,12 +28,9 @@ subroutine read_conv2grads(ctype,stype,intype,target_nreal,nobs,isubtype,subtype
    character(8),allocatable,dimension(:)  :: cdiag 
 
    character(3)   :: dtype,ctype
-   character(3)   :: subtype 
-   character(10)  :: stype,otype
-   character(15)  :: fileo,fileo_subtyp
 
-   integer nchar,file_nreal,i,ii,mype,idate,iflag,itype,iscater,igrads
-   integer lunin,lunot,target_nreal,ldtype,intype,isubtype,jsubtype
+   integer nchar,file_nreal,i,ii,mype,idate,iflag,itype
+   integer lunin,target_nreal,intype,isubtype,jsubtype
    integer nobs,idx,ioff02
 
    data lunin / 11 /

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_time.fd/conmon_read_diag.F90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_time.fd/conmon_read_diag.F90
@@ -32,6 +32,8 @@ module conmon_read_diag
    !--- implicit ---!
    implicit none
  
+   external :: stascal
+   external :: stascal_gps
 
    !--- public & private ---!
    private
@@ -232,9 +234,7 @@ module conmon_read_diag
       type(list_node_t), pointer :: list
 
       !--- local vars
-      type(list_node_t), pointer :: next => null()
-      type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, ftin, total_obs, id, idx
+      integer                    :: ii, ierr, ftin, id
 
       data ftin / 11 /
 
@@ -251,7 +251,6 @@ module conmon_read_diag
       endif
 
       call nc_diag_read_init( input_file, ftin )
-      istatus=0
 
       do ii = 1, MAX_OPEN_NCDIAG
 
@@ -332,7 +331,7 @@ module conmon_read_diag
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -359,7 +358,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Observation                     !  (obs)
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_adjusted     !  (obs)
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_unadjusted   !  (obs)
-      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_ps_nc'
@@ -535,7 +533,7 @@ module conmon_read_diag
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -563,7 +561,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_adjusted     !  (obs)
       real(r_single), dimension(:), allocatable    :: Obs_Minus_Forecast_unadjusted   !  (obs)
       real(r_single), dimension(:), allocatable    :: Forecast_Saturation_Spec_Hum    !  (obs)
-      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_q_nc'
@@ -750,7 +747,7 @@ module conmon_read_diag
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -781,7 +778,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: DiurnalWarming_at_zob           !  (obs)
       real(r_single), dimension(:), allocatable    :: SkinLayerCooling_at_zob         !  (obs)
       real(r_single), dimension(:), allocatable    :: Sensitivity_Tzob_Tr             !  (obs)
-      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_sst_nc'
@@ -980,7 +976,7 @@ module conmon_read_diag
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx, bcor_terms
+      integer                    :: ii, ierr, total_obs, idx, bcor_terms
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1010,7 +1006,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Data_Pof                        !  (obs) 
       real(r_single), dimension(:), allocatable    :: Data_Vertical_Velocity          !  (obs)
       real(r_single), dimension(:,:), allocatable  :: Bias_Correction_Terms           !  (nobs, Bias_Correction_Terms_arr_dim)
-      integer(i_kind)                              :: idate 
       integer(i_kind)                              :: jj
 
       print *, ' '
@@ -1218,7 +1213,7 @@ module conmon_read_diag
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1250,7 +1245,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: v_Observation                   !  (obs)
       real(r_single), dimension(:), allocatable    :: v_Obs_Minus_Forecast_adjusted   !  (obs)
       real(r_single), dimension(:), allocatable    :: v_Obs_Minus_Forecast_unadjusted !  (obs)
-      integer(i_kind)                              :: idate 
 
       print *, ' '
       print *, '      --> read_diag_file_uv_nc'
@@ -1449,7 +1443,7 @@ module conmon_read_diag
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, istatus, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1481,9 +1475,6 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: GPS_Type                          !  (obs)
       real(r_single), dimension(:), allocatable    :: Temperature_at_Obs_Location       !  (obs)
       real(r_single), dimension(:), allocatable    :: Specific_Humidity_at_Obs_Location !  (obs)
-
-      integer(i_kind)                              :: idate 
-
 
 
       print *, ' '
@@ -1699,11 +1690,9 @@ module conmon_read_diag
       character(8),allocatable,dimension(:)  :: cdiag 
 
       character(3)   :: dtype
-      character(10)  :: otype
-      character(15)  :: fileo,fileo_subtyp
 
-      integer nchar,file_nreal,i,ii,mype,idate,iflag,file_itype,iscater,igrads
-      integer lunin,lunot,ldtype,file_subtype
+      integer nchar,file_nreal,i,ii,mype,idate,iflag,file_itype
+      integer lunin,file_subtype
       integer idx,ioff02
 
       data lunin / 11 /

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_time.fd/mainconv_time.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_time.fd/mainconv_time.f90
@@ -1,11 +1,12 @@
 !   intype  : the observarion type like t for tem., uv for wind
 !   stype   : the observation sub type, like t120 uv220
 
-!   use conmon_read_time_diag
    use conmon_process_time_data
 
    implicit none
 
+   external ::  creatstas_ctl
+   external ::  convinfo
 
    integer np,mregion,nobs, np_gps
    integer ntype_ps,ntype_q,ntype_t,ntype_uv,ntype_gps
@@ -24,10 +25,7 @@
    character(40),dimension(mregion):: region
 
    real,dimension(mregion):: rlatmin,rlatmax,rlonmin,rlonmax
-   integer lunin,lunot,nregion
-
-   data lunin / 11 /
-   data lunot / 21 /
+   integer nregion
 
    character(100)        :: input_file          = "conv_diag"
    logical               :: netcdf              = .false.

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_time.fd/process_time_data.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_time.fd/process_time_data.f90
@@ -44,6 +44,9 @@ module conmon_process_time_data
    !--- implicit ---!
    implicit none
 
+   external ::  stascal
+   external ::  stascal_gps
+
    !--- public & private ---!
    private 
 
@@ -168,15 +171,14 @@ module conmon_process_time_data
       character(3)             :: dtype
 
       integer nchar,nreal,ii,mype,idate,iflag,itype
-      integer lunin,lunot,nreal1,nreal2,ldtype,intype
+      integer lunin
       integer ilat,ilon,ipress,iqc,iuse,imuse,iwgt,ierr1
-      integer ierr2,ierr3,ipsobs,iqobs,ioff02
-      integer i,j,k,ltype,iregion,ntype_uv
+      integer ierr2,ierr3,ioff02
+      integer ntype_uv
       integer iobg,iobgu,iobgv
       integer nobs
 
       data lunin / 11 /
-      data lunot / 21 /
 
 
       twork=0.0;qwork=0.0;uwork=0.0;vwork=0.0;uvwork=0.0
@@ -268,7 +270,7 @@ module conmon_process_time_data
       real,dimension(mregion),intent(in)     :: rlatmin,rlatmax,rlonmin,rlonmax
       integer,dimension(100),intent(in)      :: iotype_ps,iotype_q,iotype_t,iotype_uv,iotype_gps
       real(4),dimension(100,2),intent(in)    :: varqc_ps,varqc_q,varqc_t,varqc_uv,varqc_gps
-      integer, intent(in)                    :: ntype_ps,ntype_q,ntype_t,ntype_gps
+      integer, intent(in)                    :: ntype_uv,ntype_ps,ntype_q,ntype_t,ntype_gps
       integer,dimension(100),intent(in)      :: iosubtype_ps,iosubtype_q,iosubtype_uv,iosubtype_t,iosubtype_gps
 
       !========================================================================
@@ -286,11 +288,9 @@ module conmon_process_time_data
       type(data_ptr)                         :: ptr
 
       real(4),allocatable,dimension(:,:)     :: rdiag 
-      character(8),allocatable,dimension(:)  :: cdiag 
       integer                                :: nobs = 0
-      character(3)                           :: dtype
 
-      integer jj, obs_ctr, k,ltype,iregion,ntype_uv
+      integer jj, obs_ctr
 
 
       print *, '--> process_conv_nc'
@@ -795,7 +795,8 @@ module conmon_process_time_data
       integer, parameter                                    :: outfile = 61
       integer, parameter                                    :: nobsfile = 62
       character(100)                                        :: nobs_outfile
-                              
+      logical                                               :: file_exists
+
       write(6,*) '--> output_data_gps'
 
       do iregion=1,nregion
@@ -860,14 +861,22 @@ module conmon_process_time_data
       !--------------------
       !  write nobs file
       !
-      nobs_outfile='gps.nobs.ges'
-      open( nobsfile, file=nobs_outfile, form='formatted', status='new' )
+      write(6,*) 'ntype_gps = ', ntype_gps
 
-      do ltype=1,ntype_gps
-         write(nobsfile,910) ' gps', iotype_gps(ltype), ',00,', int( gpswork(1,ltype,1,1,1) + gpswork(1,ltype,1,1,2) + gpswork(1,ltype,1,1,3) )
-         910 format(A,I0,A,I6)
-      enddo
-      close( nobsfile )
+      nobs_outfile='gps.nobs.ges'
+      inquire(file=trim(nobs_outfile), exist=file_exists)
+
+      if (.not. file_exists) then
+         write(6,*) 'opening nobs_outfile = ', nobs_outfile
+         open( nobsfile, file=nobs_outfile, form='formatted', status='new' )
+
+         do ltype=1,ntype_gps
+            write(nobsfile,910) ' gps', iotype_gps(ltype), ',00,', int( gpswork(1,ltype,1,1,1) + gpswork(1,ltype,1,1,2) + gpswork(1,ltype,1,1,3) )
+            910 format(A,I0,A,I6)
+         enddo
+
+         close( nobsfile )
+      end if
 
 
       write(6,*) '<-- output_data_gps'

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_time.fd/stas_time_gps.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_time.fd/stas_time_gps.f90
@@ -20,8 +20,8 @@ subroutine stascal_gps(dtype,rdiag,nreal,n,iotype,varqc,ntype,work,&
    integer iobsu,iobsv,i,nregion,mregion,np,n,nreal,k,j
    integer ltype,ntype,intype,insubtype,nn, test_height
    real cg_term,pi,tiny
-   real valu,valv,val,val2,gesu,gesv,spdb,exp_arg,arg
-   real ress,ressu,ressv,valqc,term,wgross,cg_t,wnotgross
+   real val,val2,exp_arg,arg
+   real ress,valqc,term,wgross,cg_t,wnotgross
    real cvar_pg,cvar_b,rat_err2
 
    itype=1;isubtype=2;ilat=3;ilon=4;iheight=7;iqc=9;iuse=11;imuse=12

--- a/src/Radiance_Monitor/data_extract/sorc/radmon_mk_base.fd/make_base.f90
+++ b/src/Radiance_Monitor/data_extract/sorc/radmon_mk_base.fd/make_base.f90
@@ -1,6 +1,8 @@
 program make_base
   implicit none
 
+  external ::  errexit
+
   integer n_chan, nregion, nfile, mregion, mfile
   real rmiss
 
@@ -13,10 +15,10 @@ program make_base
   character(20) satname
   real,allocatable,dimension(:,:,:):: count, penalty
 
-  character(40) data_file, cycle_file, ctl_file, out_file
+  character(40) data_file, cycle_file, out_file
   character(40) channel_file
-  integer lungrd, luncyc, j, k, ii, ierror, hr, status
-  integer lunctl, lunout, lunchn, channels
+  integer lungrd, luncyc, j, k, ii, ierror
+  integer lunout, lunchn
   integer,allocatable,dimension(:):: iuse
   integer,allocatable,dimension(:,:):: file_ctr
 
@@ -27,10 +29,9 @@ program make_base
   real,allocatable,dimension(:,:):: min_penalty, max_penalty
 
   integer num_sdv, counter
-  real total_sdv, avg_sdv, diff_count, diff_total, diff_pen, temp
+  real total_sdv, diff_count, diff_total, diff_pen, temp
   
-  character(10) date, new_date, cycle
-  character(40) ctl_var1, ctl_var2, dummy
+  character(10) date, cycle
   logical fexist, gexist
   integer luname
 

--- a/src/Radiance_Monitor/data_extract/sorc/radmon_validate_tm.fd/bad_chan.f90
+++ b/src/Radiance_Monitor/data_extract/sorc/radmon_validate_tm.fd/bad_chan.f90
@@ -76,9 +76,6 @@ module bad_chan
       character(20), intent( in )       :: satname
       integer, intent( in )		:: channel
       
-      !--- variables
-      real                              :: count
-
       write(6,*) 'write_bad_chan, satname, channel', satname, channel
 
       write(funit,*) satname, 'channel= ', channel

--- a/src/Radiance_Monitor/data_extract/sorc/radmon_validate_tm.fd/valid.f90
+++ b/src/Radiance_Monitor/data_extract/sorc/radmon_validate_tm.fd/valid.f90
@@ -75,7 +75,7 @@ module valid
       character(20) test_satname
       character(10) base_date
 
-      integer fios, multiply_by
+      integer fios
       integer chan, region
 
       logical fexist 
@@ -179,7 +179,7 @@ module valid
       integer, intent( out )		:: iret
 
       !--- vars
-      real cnt, hi, lo, sdv2
+      real cnt, lo, sdv2
 
       write(*,*) '--> validate_count, channel, region, count ', channel, region, count
       !--- initialize vars

--- a/src/Radiance_Monitor/data_extract/sorc/radmon_validate_tm.fd/validate_time.f90
+++ b/src/Radiance_Monitor/data_extract/sorc/radmon_validate_tm.fd/validate_time.f90
@@ -19,14 +19,13 @@ program time
   character(20) satname,stringd
   character(8) date,cycle
   character(80) data_file
-  integer luname,lungrd,lunctl,lndiag,nregion
-  integer iyy,imm,idd,ihh,idhh,incr,iread,iflag
+  integer luname,lungrd
+  integer iyy,imm,idd,ihh
   integer j,k
   integer :: ios = 0
   integer :: iret 
 
   real bound, avg_cnt
-  real rmiss
   real,allocatable,dimension(:,:):: count,penalty
   real,allocatable,dimension(:):: test_pen
 
@@ -42,8 +41,7 @@ program time
   namelist /iuseflg/ test_iuse
   namelist /ichannum/ test_chan
 
-  data luname,lungrd,lunctl,lndiag / 5, 51, 52, 21 /
-  data rmiss /-999./
+  data luname,lungrd / 5, 51 /
   data stringd / '.%y4%m2%d2%h2' /
 
 

--- a/src/Radiance_Monitor/image_gen/src/radmon_ig_angle.fd/angle.f90
+++ b/src/Radiance_Monitor/image_gen/src/radmon_ig_angle.fd/angle.f90
@@ -33,8 +33,10 @@ program angle
 !************************************************************************
   implicit none
 
+  external ::  avgsdv
+
   integer ftyp,cyc,chan,open_status,prd
-  integer d1, d5_7, dmax, ctr, ndays
+  integer d1, d5_7, dmax, ndays
   integer ges, anl, avg, sdv
 
   logical exist
@@ -52,9 +54,9 @@ program angle
 
   character(len=10),allocatable,dimension(:)::times
 
-  integer luname,ldname,lpname,lsatout,lpenout
+  integer luname,ldname,lpname,lsatout
   integer ii, jj, i, j, k
-  integer nstep, io_stat, nfloats
+  integer nstep, nfloats
   integer rgn, astep
   
   real start, stepsz

--- a/src/Radiance_Monitor/image_gen/src/radmon_ig_bcoef.fd/bcoef.f90
+++ b/src/Radiance_Monitor/image_gen/src/radmon_ig_bcoef.fd/bcoef.f90
@@ -22,7 +22,7 @@ program bcoef
 
   integer ftyp,cyc,chan,open_status
 
-  logical eof, exist
+  logical exist
 
   character(20) str_nchanl
   character(60) sat_out_file
@@ -47,7 +47,7 @@ program bcoef
 !        ordang2    pred(11) = 2nd order angle term
 !        ordang1    pred(12) = 1st order angle term
 
-  integer luname,ldname,lpname,lsatchan,lsatout
+  integer luname,ldname,lpname,lsatout
   integer ii, jj
   
   real,allocatable,dimension(:,:,:):: mean,atmpath,clw,lapse2,lapse,cos_ssmis
@@ -61,7 +61,7 @@ program bcoef
   character(15)         :: satname              ='ssmis_f18'
   namelist /input/ satname,nchanl,ncycle
 
-  data luname,ldname,lpname,lsatchan / 5, 50, 51, 52 /
+  data luname,ldname,lpname / 5, 50, 51 /
 
 !************************************************************************
 ! Read namelist input

--- a/src/Radiance_Monitor/image_gen/src/radmon_ig_summary.fd/summary.f90
+++ b/src/Radiance_Monitor/image_gen/src/radmon_ig_summary.fd/summary.f90
@@ -17,17 +17,17 @@ program summary
 
    implicit none
 
-   character(10) pdate,ndate
-   character(20) stringd,str_nchanl
+   external ::  avgsdv
+
+   character(20) str_nchanl
    character(60) data_file,out_file
-   character(200) outstr
    character(len=10),allocatable,dimension(:)::times
    character(len=2), allocatable,dimension(:)::use
 
    integer,allocatable,dimension(:)::chan_nums
 
    integer luname,ldname,loname,lpname
-   integer cyc,ii,iflag,j,k,res,chan,ftyp,open_status
+   integer cyc,ii,j,k,ftyp,open_status
    integer period_one
 
    logical exist

--- a/src/Radiance_Monitor/image_gen/src/radmon_ig_time.fd/time.f90
+++ b/src/Radiance_Monitor/image_gen/src/radmon_ig_time.fd/time.f90
@@ -17,11 +17,10 @@ program gatime
 
    implicit none
 
-   character(5)  str_chan
-   character(10) pdate,ndate
-   character(20) stringd,str_nchanl,str_ncycle
-   character(60) data_file, sat_chan_file, sat_out_file
-   character(200) outstr
+   external ::  avgsdv
+
+   character(20) str_nchanl,str_ncycle
+   character(60) data_file, sat_chan_file
 
    character(60) cnt_out_file, pen_out_file, omgnbc_out_file, totcor_out_file
    character(60) omgbc_out_file
@@ -31,13 +30,12 @@ program gatime
    character(len=5), allocatable,dimension(:)::chan_nums
   
    integer luname,ldname,lpname,lsatchan,lsatout
-   integer cyc,ii,jj,iflag,j,k,res,chan,ftyp,open_status
+   integer cyc,ii,jj,j,k,chan,ftyp,open_status
    integer max_region
 
    logical exist
 
    real rmiss
-   real chan_cnt, chan_tot, chan_omgbc, chan_omgbc2
    real tot_pen, tot_cnt
 
    real,allocatable,dimension(:,:,:,:):: cnt,pen,avg_pen

--- a/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radang.fd/angle_bias.f90
+++ b/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radang.fd/angle_bias.f90
@@ -4,6 +4,9 @@ program angle
 
   implicit none
 
+  external :: create_ctl_angle
+  external :: errexit
+
   integer ntype,mregion,mstep,surf_nregion,max_surf_region
   parameter (ntype=35,mregion=25,mstep=150,max_surf_region=5)
   integer iglobal, iland, iwater, isnowice, imixed
@@ -18,9 +21,9 @@ program angle
   character(40),dimension(max_surf_region):: surf_region
   character(8)  date,suffix,cycle
 
-  integer luname,lungrd,lndiag,lunang,lunctl
+  integer luname,lungrd,lndiag,lunctl
   integer iyy,imm,idd,ihh,idhh,incr,iread,iflag,ipos
-  integer n_chan,j,i,k,ii,nsub,jiter,jj
+  integer n_chan,j,i,k,ii,nsub,jiter
   integer,dimension(mregion):: jsub
   integer,allocatable,dimension(:):: io_chan,nu_chan
   integer npred_radiag, angord
@@ -30,7 +33,7 @@ program angle
   integer nstep,iscan
   character(1) cflg
   real rang,pen
-  real weight,rlat,rlon,rmiss,obs,biascor,obsges,obsgesnbc,rread
+  real rlat,rlon,rmiss,rread
   real,dimension(2):: cor_tot,nbc_omg,bc_omg
   real,dimension(2):: cor_fixang,cor_lapse,cor_lapse2,cor_const,cor_scangl,cor_clw
   real,dimension(2):: cor_cos,cor_sin,cor_emiss
@@ -69,7 +72,6 @@ program angle
        rad_area,netcdf
 
   data luname,lungrd,lunctl,lndiag,iscan / 5, 51, 52, 21, 31 /
-  data lunang / 22 /
   data rmiss /-999./
   data stringd / '.%y4%m2%d2%h2' /
   data ftype / 'satang', 'count', 'penalty', &

--- a/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radang.fd/create_ctl_angle.f90
+++ b/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radang.fd/create_ctl_angle.f90
@@ -5,6 +5,8 @@ subroutine create_ctl_angle(ntype,ftype,n_chan,iyy,imm,idd,ihh,incr,&
 
   implicit none
 
+  external :: w3movdat
+
   integer, intent(in)                         :: ntype,n_chan,iyy,imm,idd,ihh,incr
   character(10),dimension(ntype),intent(in)   :: ftype
   character(40),intent(in)                    :: ctl_file
@@ -29,7 +31,7 @@ subroutine create_ctl_angle(ntype,ftype,n_chan,iyy,imm,idd,ihh,incr,&
   character(80),dimension(nregion):: stringr
 
   integer iuse,klev
-  integer j,i,idhh
+  integer i,idhh
   integer iyy2,imm2,idd2,ihh2,ntime
   integer, dimension(8):: ida,jda
 

--- a/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radang.fd/read_diag.f90
+++ b/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radang.fd/read_diag.f90
@@ -43,6 +43,8 @@ module read_diag
   use nc_diag_read_mod, only: nc_diag_read_init, nc_diag_read_close
   implicit none
 
+  external ::  abort
+
 ! Declare public and private
   private
 

--- a/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radbcoef.fd/bcoef.f90
+++ b/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radbcoef.fd/bcoef.f90
@@ -4,6 +4,10 @@ program bcoef
   use kinds, only: r_kind,i_kind,r_quad
 
   implicit none
+
+  external :: create_ctl_bcoef
+  external :: errexit
+
   integer ntype,maxpred
   parameter (ntype=13)
   parameter (maxpred=12)
@@ -11,7 +15,7 @@ program bcoef
   logical eof
 
   character(10),dimension(ntype):: ftype
-  character(20) dum,satname,stringd,satsis,isis,mod_satname
+  character(20) satname,stringd,satsis,isis,mod_satname
   character(10) satype,dplat
   character(80) string,data_file,ctl_file
   character(500) diag_rad
@@ -24,8 +28,8 @@ program bcoef
   integer npred_radiag
   integer(i_kind) angord,ntlapupdate, istatus
 
-  real pen,rmiss,weight,rread
-  real,allocatable,dimension(:):: wavenumbr,count,error,&
+  real pen,rmiss,rread
+  real,allocatable,dimension(:):: wavenumbr,count,&
        use,frequency,penalty,predr
   real,allocatable,dimension(:,:):: coefs
   real(r_kind)  tlapm, tsum

--- a/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radbcoef.fd/create_ctl_bcoef.f90
+++ b/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radbcoef.fd/create_ctl_bcoef.f90
@@ -4,6 +4,8 @@ subroutine create_ctl_bcoef(ntype,ftype,n_chan,iyy,imm,idd,ihh,idhh,&
 
   implicit none
 
+  external ::  w3movdat
+
   integer, intent(in)                        :: ntype,n_chan,iyy,imm,idd,ihh,idhh
   character(10),dimension(ntype),intent(in)  :: ftype
   integer, intent(in)                        :: lunctl,incr,little_endian
@@ -16,13 +18,11 @@ subroutine create_ctl_bcoef(ntype,ftype,n_chan,iyy,imm,idd,ihh,idhh,&
 
 
   character(3),dimension(12):: mon
-  character(3):: clatmin,clatmax
-  character(4):: clonmin,clonmax
   character(13) stringd
   character(40) grad_file
   character(80) string
 
-  integer iuse,j,i
+  integer iuse,i
   integer iyy2,imm2,idd2,ihh2,ntime
   integer,dimension(8):: ida,jda
 

--- a/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radbcoef.fd/read_diag.f90
+++ b/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radbcoef.fd/read_diag.f90
@@ -43,6 +43,8 @@ module read_diag
   use nc_diag_read_mod, only: nc_diag_read_init, nc_diag_read_close
   implicit none
 
+  external :: abort
+
 ! Declare public and private
   private
 

--- a/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radbcor.fd/bcor.f90
+++ b/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radbcor.fd/bcor.f90
@@ -7,6 +7,11 @@ program bcor
   use kinds, only : i_kind
 
   implicit none
+
+  external :: avgsdv
+  external :: create_ctl_bcor
+  external :: errexit
+
   integer ntype,mregion,surf_nregion,max_surf_region
   parameter (ntype=30,mregion=25,max_surf_region=5)
   integer iglobal, iland, iwater, isnowice, imixed
@@ -14,7 +19,7 @@ program bcor
 
   character(10),dimension(ntype):: ftype
   character(20) satname,stringd,satsis,mod_satname
-  character(10) dum,satype,dplat
+  character(10) satype,dplat
   character(80) string,data_file,ctl_file
   character(500) diag_rad
   character(40),dimension(max_surf_region):: region
@@ -22,14 +27,14 @@ program bcor
 
   integer luname,lungrd,lunctl,lndiag
   integer iyy,imm,idd,ihh,idhh,incr,iread,iflag
-  integer n_chan,j,idsat,i,k,ii,nsub
+  integer n_chan,j,i,k,ii,nsub
   integer,dimension(mregion):: jsub
   integer,allocatable,dimension(:):: io_chan,nu_chan
   integer npred_radiag,angord
   integer(i_kind)       :: istatus
 
   real pen,rread
-  real weight,rlat,rlon,rmiss,obs,biascor,obsges,obsgesnbc,rterm
+  real rlat,rlon,rmiss
   real,dimension(2):: cor_total,cor_fixang,cor_lapse,cor_lapse2,&
        cor_const,cor_scangl,cor_clw,cor_cos_ssmis,cor_sin_ssmis,&
        cor_emiss,cor_ordang4,cor_ordang3,cor_ordang2,cor_ordang1
@@ -41,8 +46,6 @@ program bcor
   real,allocatable,dimension(:,:,:):: total_cor,fixang_cor,lapse_cor,&
        lapse2_cor,const_cor,scangl_cor,clw_cor,cos_ssmis_cor,sin_ssmis_cor,&
        emiss_cor,ordang4_cor,ordang3_cor,ordang2_cor,ordang1_cor
-
-  logical no_obs
 
 ! Variables for reading satellite data
   type(diag_header_fix_list )             :: header_fix

--- a/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radbcor.fd/create_ctl_bcor.f90
+++ b/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radbcor.fd/create_ctl_bcor.f90
@@ -5,6 +5,8 @@ subroutine create_ctl_bcor(ntype,ftype,n_chan,iyy,imm,idd,ihh,idhh,&
 
   implicit none
 
+  external :: w3movdat
+
   integer,intent(in)                        :: ntype,lunctl,nregion,little_endian
   character(10),dimension(ntype),intent(in) :: ftype
   integer,intent(in)                        :: n_chan,iyy,imm,idd,ihh,idhh,incr
@@ -27,7 +29,7 @@ subroutine create_ctl_bcor(ntype,ftype,n_chan,iyy,imm,idd,ihh,idhh,&
   character(80) string
   character(80),dimension(nregion):: stringr
 
-  integer iyy2,imm2,idd2,ihh2,ntime,j,i,iuse
+  integer iyy2,imm2,idd2,ihh2,ntime,i,iuse
   integer,dimension(8):: ida,jda
 
   real wavelength

--- a/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radbcor.fd/read_diag.f90
+++ b/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radbcor.fd/read_diag.f90
@@ -43,6 +43,8 @@ module read_diag
   use nc_diag_read_mod, only: nc_diag_read_init, nc_diag_read_close
   implicit none
 
+  external ::  abort
+
 ! Declare public and private
   private
 

--- a/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radtime.fd/bad_chan.f90
+++ b/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radtime.fd/bad_chan.f90
@@ -51,7 +51,6 @@ module bad_chan
       character(60)                     :: fname
 
 
-!      write(*,*) '--> open_bad_chan_file, date, cycle = ', date, cycle
       !--- build the file name
       fname = 'bad_chan.' // trim(date) // trim(cycle)
 
@@ -76,9 +75,6 @@ module bad_chan
       character(20), intent( in )       :: satname
       integer, intent( in )		:: channel
       
-      !--- variables
-      real                              :: count
-
       write(6,*) 'write_bad_chan, satname, channel', satname, channel
 
       write(funit,*) satname, 'channel= ', channel
@@ -87,7 +83,6 @@ module bad_chan
 
 
     subroutine close_bad_chan_file( )
-!      write(6,*) '--> close_bad_chan_file'
       close( funit ) 
     end subroutine close_bad_chan_file
 

--- a/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radtime.fd/create_ctl_time.f90
+++ b/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radtime.fd/create_ctl_time.f90
@@ -29,12 +29,14 @@ subroutine create_ctl_time(ntype,ftype,n_chan,iyy,imm,idd,ihh,idhh,&
   character(80),dimension(nregion):: stringr
 
   integer iuse
-  integer j,i
+  integer i
   integer iyy2,imm2,idd2,ihh2,ntime
   integer,dimension(8):: ida,jda
 
   real wavelength
   real,dimension(5):: fha
+
+  external ::  w3movdat
 
   data stringd / '.%y4%m2%d2%h2' /
   data mon / 'jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', &

--- a/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radtime.fd/read_diag.f90
+++ b/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radtime.fd/read_diag.f90
@@ -43,6 +43,8 @@ module read_diag
   use nc_diag_read_mod, only: nc_diag_read_init, nc_diag_read_close
   implicit none
 
+  external :: abort
+
 ! Declare public and private
   private
 

--- a/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radtime.fd/time.f90
+++ b/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radtime.fd/time.f90
@@ -22,30 +22,26 @@ program time
   parameter (iglobal=1, iland=2, iwater=3, isnowice=4, imixed=5)
 
   character(10),dimension(ntype):: ftype
-  character(8) stid
   character(20) satname,stringd,satsis
-  character(10) dum,satype,dplat
+  character(10) satype,dplat
   character(80) string,data_file,dfile,ctl_file
   character(500) diag_rad
   character(40),dimension(max_surf_region):: region
-  character(40),dimension(mregion):: surf_region
-  character :: command
   character(8) date,suffix,cycle
 
   integer luname,lungrd,lunctl,lndiag,nregion
   integer iyy,imm,idd,ihh,idhh,incr,iread,iflag
-  integer n_chan,j,idsat,i,k,ii,nreg
+  integer n_chan,j,i,k,ii,nreg
   integer,dimension(mregion):: jsub
   integer,allocatable,dimension(:):: io_chan,nu_chan
   integer :: ios = 0
-  integer :: channel_obs
   integer :: iret, ier, ver
   integer npred_radiag
   integer(i_kind)       :: istatus
 
   real rread, pen, bound
-  real rlat, rlon, rmiss, obs
-  real,dimension(2):: cor_tot,nbc_omg,bc_omg
+  real rlat, rlon, rmiss
+  real,dimension(2):: cor_tot
   real,dimension(2):: omgbc, omgnbc
   real,dimension(max_surf_region):: rlatmin,rlatmax,rlonmin,rlonmax
 
@@ -63,7 +59,7 @@ program time
 
   logical  valid_count, valid_penalty
   integer  nsnow, nland, nwater, nice, nmixed, ntotal
-  integer  nnsnow, nnland, nnwater, nnmixed, nntotal
+  integer  nnsnow, nnland, nnwater, nnmixed
   real     avg_cnt
 
 ! Namelist with defaults
@@ -77,6 +73,9 @@ program time
   logical               :: netcdf               = .false.
   namelist /input/ satname,iyy,imm,idd,ihh,idhh,incr,nchanl,&
        suffix,imkctl,imkdata,retrieval,gesanl,little_endian,rad_area,netcdf
+
+  external              :: create_ctl_time
+  external              :: errexit
 
   data luname,lungrd,lunctl,lndiag / 5, 51, 52, 21 /
   data rmiss /-999./

--- a/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radtime.fd/valid.f90
+++ b/src/Radiance_Monitor/nwprod/radmon_shared/sorc/verf_radtime.fd/valid.f90
@@ -75,7 +75,7 @@ module valid
       character(20) test_satname
       character(10) base_date
 
-      integer fios, multiply_by
+      integer fios
       integer chan, region
 
       logical fexist 
@@ -158,7 +158,7 @@ module valid
       integer, intent( out )		:: iret
 
       !--- vars
-      real cnt, hi, lo, sdv2
+      real cnt, lo, sdv2
 
       write(*,*) '--> validate_count, channel, region, count ', channel, region, count
       !--- initialize vars


### PR DESCRIPTION
This PR removes all of the compiler warnings from the RadMon and most warnings (~85%) from the ConMon code when compiled in 'debug' mode.  The changes remove unused variables and add external declarations for called subroutines.

There is one small bug fix included for `src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_time.fd/process_time_data.f90` to avoid overwriting an output file.

Testing has been conducted in two phases.  The ConMon changes have been tested using the cnvstat output from the operational GFS over the past week.  The RadMon changes have been tested using a short parallel run using canned C96 data.  The RadMon ran without errors and the plotted data was as expected.

The remaining compiler warnings for the ConMon will be addressed in a separate issue & PR as time permits.


Closes #210 