### PR TITLE
Fix ci gcc build failure

### DIFF
--- a/ci/spack.yaml
+++ b/ci/spack.yaml
@@ -3,6 +3,7 @@ spack:
   packages:
     all:
       compiler: [intel, gcc@10:10]
+      target: [x86_64]
   specs:
   - netcdf-c@4.9.2
   - netcdf-fortran@4.6.0


### PR DESCRIPTION
Fix one more ci build issue.  This change tells spack to compile everything for the baseline x86_64 ISA rather than the specific micro-architecture of whichever runner happens to run the setup job. The gsi-monitor build job then restores that same cache and the binaries run fine even on a different physical runner, or so copilot informs me.  
