### PR TITLE
Fix remaining Debug mode compiler warnings 

### DIFF
--- a/modulefiles/ursa.intel-run.lua
+++ b/modulefiles/ursa.intel-run.lua
@@ -11,7 +11,7 @@ local grads_ver=os.getenv("grads_ver") or "2.2.3"
 local tar_ver=os.getenv("tar_ver") or "1.34"
 
 load(pathJoin("stack-oneapi", stack_oneapi_ver))
-load(pathJoin("stack-intel-oneapi-mpi", stack_intel_oneapi_mpiver))
+load(pathJoin("stack-intel-oneapi-mpi", stack_intel_oneapi_mpi_ver))
 
 load(pathJoin("grads", grads_ver))
 load(pathJoin("tar", tar_ver))

--- a/modulefiles/ursa.intel-run.lua
+++ b/modulefiles/ursa.intel-run.lua
@@ -2,17 +2,19 @@ help([[
 ]])
 
 -- Spack Stack installation specs
-prepend_path("MODULEPATH", "/apps/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.2.1/install/modulefiles/Core")
+prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.2.1/install/modulefiles/Core")
 
 local stack_oneapi_ver=os.getenv("stack_oneapi_ver") or "2024.2.1"
 local stack_intel_oneapi_mpi_ver=os.getenv("stack_intel_oneapi_mpi_ver") or "2021.13"
 
 local grads_ver=os.getenv("grads_ver") or "2.2.3"
+local tar_ver=os.getenv("tar_ver") or "1.34"
 
 load(pathJoin("stack-oneapi", stack_oneapi_ver))
 load(pathJoin("stack-intel-oneapi-mpi", stack_intel_oneapi_mpiver))
 
 load(pathJoin("grads", grads_ver))
+load(pathJoin("tar", tar_ver))
 
 load("common-run")
 

--- a/modulefiles/ursa.intel.lua
+++ b/modulefiles/ursa.intel.lua
@@ -9,7 +9,7 @@ local stack_oneapi_ver=os.getenv("stack_oneapi_ver") or "2024.2.1"
 local stack_intel_oneapi_mpi_ver=os.getenv("stack_intel_oneapi_mpi_ver") or "2021.13"
 
 load(pathJoin("stack-oneapi", stack_oneapi_ver))
-load(pathJoin("stack-intel-oneapi-mpi", stack_intel_oneapi_mpiver))
+load(pathJoin("stack-intel-oneapi-mpi", stack_intel_oneapi_mpi_ver))
 
 load("common")
 

--- a/modulefiles/ursa.intel.lua
+++ b/modulefiles/ursa.intel.lua
@@ -1,14 +1,15 @@
 help([[
 ]])
 
+
 -- Spack Stack installation specs
 prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.2.1/install/modulefiles/Core")
 
 local stack_oneapi_ver=os.getenv("stack_oneapi_ver") or "2024.2.1"
-local stack_intel_oneapi_mpi=os.getenv("stack_intel_oneapi_mpi") or "2021.13"
+local stack_intel_oneapi_mpi_ver=os.getenv("stack_intel_oneapi_mpi_ver") or "2021.13"
 
 load(pathJoin("stack-oneapi", stack_oneapi_ver))
-load(pathJoin("stack-intel-oneapi-mpi", stack_intel_oneapi_mpi))
+load(pathJoin("stack-intel-oneapi-mpi", stack_intel_oneapi_mpiver))
 
 load("common")
 

--- a/parm/Mon_config
+++ b/parm/Mon_config
@@ -31,7 +31,8 @@ export MY_MACHINE=$machine_id
 #         then I'll open an issue for the change to those machines.
 #
 if [[ $MY_MACHINE = "wcoss2" || $MY_MACHINE = "hera" || $MY_MACHINE = "orion" || \
-      $MY_MACHINE = "hercules" || $MY_MACHINE = "s4" || $MY_MACHINE = "jet" ]]; then
+      $MY_MACHINE = "hercules" || $MY_MACHINE = "s4" || $MY_MACHINE = "jet" || \
+      $MY_MACHINE = "ursa" ]]; then
    source $DIR_ROOT/ush/module-setup.sh
    module use $DIR_ROOT/modulefiles
    module load ${MACHINE_ID}.${COMPILER}-run
@@ -77,6 +78,17 @@ case $MY_MACHINE in
       tankdir="/scratch1/NCEPDEV/da/$USER/save/nbns"
       ptmp="/scratch2/NCEPDEV/stmp3/$USER"
       stmp="/scratch2/NCEPDEV/stmp1/$USER"
+      queue=""
+      project=""
+      account="da-cpu"
+      ;;
+
+   ursa)
+      export SUB=/apps/slurm/default/bin/sbatch
+
+      tankdir="/scratch3/NCEPDEV/da/$USER/save/nbns"
+      ptmp="/scratch3/NCEPDEV/stmp/$USER"
+      stmp="/scratch3/NCEPDEV/stmp/$USER"
       queue=""
       project=""
       account="da-cpu"

--- a/src/Conventional_Monitor/data_extract/ush/ConMon_DE.sh
+++ b/src/Conventional_Monitor/data_extract/ush/ConMon_DE.sh
@@ -242,7 +242,7 @@ if [ -s $cnvstat  -a -s $pgrbf00 -a -s $pgrbf06 ]; then
 		${HOMEgdas_conmon}/jobs/JGDAS_ATMOS_CONMON
       
       elif [[ $MY_MACHINE = "wcoss2" ]]; then
-        $SUB -V -q $JOB_QUEUE -A $ACCOUNT -o ${logfile} -e ${logfile} -l walltime=45:00 -N ${jobname} \
+        $SUB -V -q $JOB_QUEUE -A $ACCOUNT -o ${logfile} -e ${logfile} -l walltime=2:15:00 -N ${jobname} \
 		-l select=1:mem=8gb ${HOMEgdas_conmon}/jobs/JGDAS_ATMOS_CONMON
       fi
 

--- a/src/Conventional_Monitor/data_extract/ush/ConMon_DE.sh
+++ b/src/Conventional_Monitor/data_extract/ush/ConMon_DE.sh
@@ -197,6 +197,16 @@ if [[ -e ${C_TANKDIR}/info/gdas_conmon_base.txt ]]; then
    export conmon_base=${C_TANKDIR}/info/gdas_conmon_base.txt
 fi
 
+if [ ! -s $cnvstat ]; then
+   echo "unable to access $cnvstat"
+fi
+
+if [ ! -s $pgrbf00 ]; then
+   echo "unable to access $pgrbf00"
+fi
+if [ ! -s $pgrbf06 ]; then
+   echo "unable to access $pgrbf06"
+fi
 
 exit_value=0
 if [ -s $cnvstat  -a -s $pgrbf00 -a -s $pgrbf06 ]; then
@@ -205,7 +215,6 @@ if [ -s $cnvstat  -a -s $pgrbf00 -a -s $pgrbf06 ]; then
    #------------------------------------------------------------------
    if [ -s $pgrbf06 ]; then
 
-      echo "Ok to proceed with DE"
       logdir=${C_LOGDIR}
       if [[ ! -d ${logdir} ]]; then
          mkdir -p ${logdir}
@@ -220,6 +229,11 @@ if [ -s $cnvstat  -a -s $pgrbf00 -a -s $pgrbf06 ]; then
             $MY_MACHINE = "orion" || $MY_MACHINE = "hercules" ]]; then
          $SUB -A $ACCOUNT --ntasks=1 --time=00:30:00 \
 		-p ${SERVICE_PARTITION} -J ${jobname} -o $C_LOGDIR/DE.${PDY}.${CYC}.log \
+		${HOMEgdas_conmon}/jobs/JGDAS_ATMOS_CONMON
+     
+      elif [[ $MY_MACHINE = "ursa" ]]; then
+         $SUB -A $ACCOUNT --ntasks=1 --time=01:30:00 \
+		-J ${jobname} -o $C_LOGDIR/DE.${PDY}.${CYC}.log \
 		${HOMEgdas_conmon}/jobs/JGDAS_ATMOS_CONMON
 
       elif [[ $MY_MACHINE = "jet" ]]; then

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_lev.fd/conmon_read_diag.F90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_lev.fd/conmon_read_diag.F90
@@ -1458,7 +1458,7 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Model_Elevation                   !  (obs)
       real(r_single), dimension(:), allocatable    :: Setup_QC_Mark                     !  (obs)
       real(r_single), dimension(:), allocatable    :: Prep_Use_Flag                     !  (obs)
-      !jjjjjjreal(r_single), dimension(:), allocatable    :: Nonlinear_QC_Var_Jb               !  (obs)
+      !real(r_single), dimension(:), allocatable    :: Nonlinear_QC_Var_Jb               !  (obs)
       real(r_single), dimension(:), allocatable    :: Nonlinear_QC_Rel_Wgt              !  (obs)
       real(r_single), dimension(:), allocatable    :: Analysis_Use_Flag                 !  (obs)
       real(r_single), dimension(:), allocatable    :: Errinv_Input                      !  (obs)

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_lev.fd/conmon_read_diag.F90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_lev.fd/conmon_read_diag.F90
@@ -159,7 +159,7 @@ module conmon_read_diag
 
       if ( netcdf ) then
          write(6,*) ' call nc read subroutine'
-         call read_diag_file_nc( input_file, return_all, ctype, intype, expected_nreal, nobs, in_subtype, list )
+         call read_diag_file_nc( input_file, return_all, ctype, intype, nobs, in_subtype, list )
       else
          call read_diag_file_bin( input_file,return_all, ctype, intype, expected_nreal,nobs,in_subtype, list )
       end if
@@ -205,7 +205,7 @@ module conmon_read_diag
       !
       if ( netcdf ) then
          write(6,*) ' call nc retrieve all routine'
-         call read_diag_file_nc( input_file, return_all, ctype, intype, expected_nreal, nobs, in_subtype, list )
+         call read_diag_file_nc( input_file, return_all, ctype, intype, nobs, in_subtype, list )
       else
          write(6,*) ' call bin retrieve all routine'
          call read_diag_file_bin( input_file,return_all, ctype, intype, expected_nreal,nobs,in_subtype, list )
@@ -221,13 +221,13 @@ module conmon_read_diag
    !
    !  NetCDF read routine
    !-------------------------------
-   subroutine read_diag_file_nc( input_file, return_all, ctype, intype, expected_nreal, nobs, in_subtype, list )
+   subroutine read_diag_file_nc( input_file, return_all, ctype, intype, nobs, in_subtype, list )
 
       !--- interface 
       character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
@@ -267,22 +267,22 @@ module conmon_read_diag
       select case ( trim( adjustl( ctype ) ) )
    
          case ( 'gps' ) 
-            call read_diag_file_gps_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_gps_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 'ps' ) 
-            call read_diag_file_ps_nc(  input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_ps_nc(  return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 'q' ) 
-            call read_diag_file_q_nc(   input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_q_nc(   return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 'sst' )
-            call read_diag_file_sst_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_sst_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 't' ) 
-            call read_diag_file_t_nc(   input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_t_nc(   return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 'uv' ) 
-            call read_diag_file_uv_nc(  input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_uv_nc(  return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case default
             print *, 'ERROR:  unmatched ctype :', ctype
@@ -315,21 +315,20 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for ps data types in netcdf files
    !
-   subroutine read_diag_file_ps_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
+   subroutine read_diag_file_ps_nc( return_all, ftin, ctype, intype,nobs,in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx, id
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -365,7 +364,8 @@ module conmon_read_diag
       !
       if( nc_diag_read_check_dim( 'nobs' )) then
          total_obs = nc_diag_read_get_dim(ftin,'nobs')
-         ncdiag_open_status(ii)%num_records = total_obs
+         id = find_ncdiag_id(ftin)
+         ncdiag_open_status(id)%num_records = total_obs
          print *, '          total_obs = ', total_obs
       else
          print *, 'ERROR:  unable to read nobs'
@@ -517,21 +517,20 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for q data types in netcdf files
    !
-   subroutine read_diag_file_q_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
+   subroutine read_diag_file_q_nc( return_all, ftin, ctype, intype,nobs,in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx, id
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -568,7 +567,8 @@ module conmon_read_diag
       !
       if( nc_diag_read_check_dim( 'nobs' )) then
          total_obs = nc_diag_read_get_dim(ftin,'nobs')
-         ncdiag_open_status(ii)%num_records = total_obs
+         id = find_ncdiag_id(ftin)
+         ncdiag_open_status(id)%num_records = total_obs
          print *, '          total_obs = ', total_obs
       else
          print *, 'ERROR:  unable to read nobs'
@@ -731,21 +731,20 @@ module conmon_read_diag
    !  NOTE2:  There are known discrepencies between the contents
    !          of sst obs in binary and NetCDF files. 
    !
-   subroutine read_diag_file_sst_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
+   subroutine read_diag_file_sst_nc( return_all, ftin, ctype, intype,nobs,in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx, id
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -785,7 +784,8 @@ module conmon_read_diag
       !
       if( nc_diag_read_check_dim( 'nobs' )) then
          total_obs = nc_diag_read_get_dim(ftin,'nobs')
-         ncdiag_open_status(ii)%num_records = total_obs
+         id = find_ncdiag_id(ftin)
+         ncdiag_open_status(id)%num_records = total_obs
          print *, '          total_obs = ', total_obs
       else
          print *, 'ERROR:  unable to read nobs'
@@ -960,14 +960,13 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for t data types in netcdf files
    !
-   subroutine read_diag_file_t_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+   subroutine read_diag_file_t_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
@@ -1004,16 +1003,14 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Data_Pof                        !  (obs) 
       real(r_single), dimension(:), allocatable    :: Data_Vertical_Velocity          !  (obs)
       real(r_single), dimension(:,:), allocatable  :: Bias_Correction_Terms           !  (nobs, Bias_Correction_Terms_arr_dim)
-      integer(i_kind)                              :: jj
+      integer(i_kind)                              :: jj, id
 
       print *, ' '
       print *, '      --> read_diag_file_t_nc'
 
-      print *, '            input_file = ', input_file
       print *, '            ftin       = ', ftin
       print *, '            ctype      = ', ctype
       print *, '            intype     = ', intype  
-      print *, '            expected_nreal = ', expected_nreal 
       print *, '            in_subtype = ', in_subtype
 
 
@@ -1021,7 +1018,8 @@ module conmon_read_diag
       !
       if( nc_diag_read_check_dim( 'nobs' )) then
          total_obs = nc_diag_read_get_dim(ftin,'nobs')
-         ncdiag_open_status(ii)%num_records = total_obs
+         id = find_ncdiag_id(ftin)
+         ncdiag_open_status(id)%num_records = total_obs
       else
          print *, 'ERROR:  unable to read nobs'
          ierr=1
@@ -1197,21 +1195,20 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for uv data types in netcdf files
    !
-   subroutine read_diag_file_uv_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+   subroutine read_diag_file_uv_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, total_obs, idx
+      integer                    :: ii, id, ierr, total_obs, idx
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1252,7 +1249,8 @@ module conmon_read_diag
       !
       if( nc_diag_read_check_dim( 'nobs' )) then
          total_obs = nc_diag_read_get_dim(ftin,'nobs')
-         ncdiag_open_status(ii)%num_records = total_obs
+         id = find_ncdiag_id(ftin)
+         ncdiag_open_status(id)%num_records = total_obs
          print *, '          total_obs = ', total_obs
       else
          print *, 'ERROR:  unable to read nobs'
@@ -1427,21 +1425,20 @@ module conmon_read_diag
    !          in binary and NetCDF formatted diag files. See
    !          comments below.
    !
-   subroutine read_diag_file_gps_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
+   subroutine read_diag_file_gps_nc( return_all, ftin, ctype, intype,nobs,in_subtype, list )
  
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx, id
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1454,14 +1451,14 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Latitude                          !  (obs)
       real(r_single), dimension(:), allocatable    :: Longitude                         !  (obs)
       real(r_single), dimension(:), allocatable    :: Incremental_Bending_Angle         !  (obs)
-      real(r_single), dimension(:), allocatable    :: Station_Elevation                 !  (obs)
+      !real(r_single), dimension(:), allocatable    :: Station_Elevation                 !  (obs)
       real(r_single), dimension(:), allocatable    :: Pressure                          !  (obs)
       real(r_single), dimension(:), allocatable    :: Height                            !  (obs)
       real(r_single), dimension(:), allocatable    :: Time                              !  (obs)
       real(r_single), dimension(:), allocatable    :: Model_Elevation                   !  (obs)
       real(r_single), dimension(:), allocatable    :: Setup_QC_Mark                     !  (obs)
       real(r_single), dimension(:), allocatable    :: Prep_Use_Flag                     !  (obs)
-      real(r_single), dimension(:), allocatable    :: Nonlinear_QC_Var_Jb               !  (obs)
+      !jjjjjjreal(r_single), dimension(:), allocatable    :: Nonlinear_QC_Var_Jb               !  (obs)
       real(r_single), dimension(:), allocatable    :: Nonlinear_QC_Rel_Wgt              !  (obs)
       real(r_single), dimension(:), allocatable    :: Analysis_Use_Flag                 !  (obs)
       real(r_single), dimension(:), allocatable    :: Errinv_Input                      !  (obs)
@@ -1483,7 +1480,8 @@ module conmon_read_diag
       !
       if( nc_diag_read_check_dim( 'nobs' )) then
          total_obs = nc_diag_read_get_dim(ftin,'nobs')
-         ncdiag_open_status(ii)%num_records = total_obs
+         id = find_ncdiag_id(ftin)
+         ncdiag_open_status(id)%num_records = total_obs
          print *, '          total_obs = ', total_obs
       else
          print *, 'ERROR:  unable to read nobs'

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_lev.fd/grads_lev.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_lev.fd/grads_lev.f90
@@ -8,7 +8,7 @@
 
 
 subroutine grads_lev(fileo,ifileo,nobs,nreal,nlev,plev,iscater,igrads,&
-                        levcard,hint,isubtype,subtype,list,run)
+                        hint,subtype,list,run)
 
    use generic_list
    use data
@@ -16,6 +16,8 @@ subroutine grads_lev(fileo,ifileo,nobs,nreal,nlev,plev,iscater,igrads,&
    implicit none
 
    external :: rm_dups
+   external :: getpres
+
 
    type(list_node_t), pointer   :: list
    type(list_node_t), pointer   :: next => null()
@@ -31,9 +33,7 @@ subroutine grads_lev(fileo,ifileo,nobs,nreal,nlev,plev,iscater,igrads,&
    character(3) ::  run             ! ges or anl
 
    character(30) :: files, filegrad, file_nobs
-   character(10) :: levcard 
 
-   integer(4):: isubtype
    integer i,j,k,ctr,obs_ctr
    integer ilat,ilon,ipres,itime,iweight,ndup
 

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_lev.fd/maingrads_lev.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_lev.fd/maingrads_lev.f90
@@ -18,14 +18,13 @@
    interface
 
       subroutine grads_lev(fileo,ifileo,nobs,nreal,nlev,plev,iscater,igrads, &
-                           levcard,hint,isubtype,subtype,list,run)
+                           hint,subtype,list,run)
          use generic_list
 
          integer ifileo
          character(ifileo)              :: fileo
-         integer                        :: nobs,nreal,nlev,iscater,igrads,isubtype
+         integer                        :: nobs,nreal,nlev,iscater,igrads
          real(4),dimension(nlev)        :: plev
-         character(10)                  :: levcard
          real*4                         :: hint
          character(3)                   :: subtype
          type(list_node_t), pointer     :: list
@@ -82,16 +81,16 @@
    if( nobs > 0 ) then
       if(trim(levcard) == 'alllev' ) then
          call grads_lev(stype,lstype,nobs,nreal,n_alllev,palllev,iscater, &
-                        igrads,levcard,hint,isubtype,subtype,list,run)
+                        igrads,hint,subtype,list,run)
       else if (trim(levcard) == 'acft' ) then
          call grads_lev(stype,lstype,nobs,nreal,n_acft,pacft,iscater,igrads,&
-                        levcard,hint,isubtype,subtype,list,run)
+                        hint,subtype,list,run)
       else if(trim(levcard) == 'lowlev' ) then
          call grads_lev(stype,lstype,nobs,nreal,n_lowlev,plowlev,iscater,&
-                        igrads,levcard,hint,isubtype,subtype,list,run)
+                        igrads,hint,subtype,list,run)
       else if(trim(levcard) == 'upair' ) then
          call grads_lev(stype,lstype,nobs,nreal,n_upair,pupair,iscater,&
-                        igrads,levcard,hint,isubtype,subtype,list,run)
+                        igrads,hint,subtype,list,run)
       end if
    else
       print *, 'NOBS <= 0, NO OUTPUT GENERATED' 

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_mandlev.fd/conmon_read_diag.F90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_mandlev.fd/conmon_read_diag.F90
@@ -159,7 +159,7 @@ module conmon_read_diag
 
       if ( netcdf ) then
          write(6,*) ' call nc read subroutine'
-         call read_diag_file_nc( input_file, return_all, ctype, intype, expected_nreal, nobs, in_subtype, list )
+         call read_diag_file_nc( input_file, return_all, ctype, intype, nobs, in_subtype, list )
       else
          call read_diag_file_bin( input_file,return_all, ctype, intype, expected_nreal,nobs,in_subtype, list )
       end if
@@ -205,7 +205,7 @@ module conmon_read_diag
       !
       if ( netcdf ) then
          write(6,*) ' call nc retrieve all routine'
-         call read_diag_file_nc( input_file, return_all, ctype, intype, expected_nreal, nobs, in_subtype, list )
+         call read_diag_file_nc( input_file, return_all, ctype, intype, nobs, in_subtype, list )
       else
          write(6,*) ' call bin retrieve all routine'
          call read_diag_file_bin( input_file,return_all, ctype, intype, expected_nreal,nobs,in_subtype, list )
@@ -221,13 +221,13 @@ module conmon_read_diag
    !
    !  NetCDF read routine
    !-------------------------------
-   subroutine read_diag_file_nc( input_file, return_all, ctype, intype, expected_nreal, nobs, in_subtype, list )
+   subroutine read_diag_file_nc( input_file, return_all, ctype, intype, nobs, in_subtype, list )
 
       !--- interface 
       character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
@@ -268,22 +268,22 @@ module conmon_read_diag
       select case ( trim( adjustl( ctype ) ) )
    
          case ( 'gps' ) 
-            call read_diag_file_gps_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_gps_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 'ps' ) 
-            call read_diag_file_ps_nc(  input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_ps_nc(  return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 'q' ) 
-            call read_diag_file_q_nc(   input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_q_nc(   return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 'sst' )
-            call read_diag_file_sst_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_sst_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 't' ) 
-            call read_diag_file_t_nc(   input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_t_nc(   return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 'uv' ) 
-            call read_diag_file_uv_nc(  input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_uv_nc(  return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case default
             print *, 'ERROR:  unmatched ctype :', ctype
@@ -316,14 +316,13 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for ps data types in netcdf files
    !
-   subroutine read_diag_file_ps_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
+   subroutine read_diag_file_ps_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
@@ -518,14 +517,13 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for q data types in netcdf files
    !
-   subroutine read_diag_file_q_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
+   subroutine read_diag_file_q_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
@@ -732,14 +730,13 @@ module conmon_read_diag
    !  NOTE2:  There are known discrepencies between the contents
    !          of sst obs in binary and NetCDF files. 
    !
-   subroutine read_diag_file_sst_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
+   subroutine read_diag_file_sst_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
@@ -961,14 +958,13 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for t data types in netcdf files
    !
-   subroutine read_diag_file_t_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+   subroutine read_diag_file_t_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
@@ -1010,11 +1006,9 @@ module conmon_read_diag
       print *, ' '
       print *, '      --> read_diag_file_t_nc'
 
-      print *, '            input_file = ', input_file
       print *, '            ftin       = ', ftin
       print *, '            ctype      = ', ctype
       print *, '            intype     = ', intype  
-      print *, '            expected_nreal = ', expected_nreal 
       print *, '            in_subtype = ', in_subtype
 
 
@@ -1198,14 +1192,13 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for uv data types in netcdf files
    !
-   subroutine read_diag_file_uv_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+   subroutine read_diag_file_uv_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
@@ -1428,14 +1421,13 @@ module conmon_read_diag
    !          in binary and NetCDF formatted diag files. See
    !          comments below.
    !
-   subroutine read_diag_file_gps_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
+   subroutine read_diag_file_gps_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
  
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
@@ -1455,14 +1447,14 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Latitude                          !  (obs)
       real(r_single), dimension(:), allocatable    :: Longitude                         !  (obs)
       real(r_single), dimension(:), allocatable    :: Incremental_Bending_Angle         !  (obs)
-      real(r_single), dimension(:), allocatable    :: Station_Elevation                 !  (obs)
+      !real(r_single), dimension(:), allocatable    :: Station_Elevation                 !  (obs)
       real(r_single), dimension(:), allocatable    :: Pressure                          !  (obs)
       real(r_single), dimension(:), allocatable    :: Height                            !  (obs)
       real(r_single), dimension(:), allocatable    :: Time                              !  (obs)
       real(r_single), dimension(:), allocatable    :: Model_Elevation                   !  (obs)
       real(r_single), dimension(:), allocatable    :: Setup_QC_Mark                     !  (obs)
       real(r_single), dimension(:), allocatable    :: Prep_Use_Flag                     !  (obs)
-      real(r_single), dimension(:), allocatable    :: Nonlinear_QC_Var_Jb               !  (obs)
+      !real(r_single), dimension(:), allocatable    :: Nonlinear_QC_Var_Jb               !  (obs)
       real(r_single), dimension(:), allocatable    :: Nonlinear_QC_Rel_Wgt              !  (obs)
       real(r_single), dimension(:), allocatable    :: Analysis_Use_Flag                 !  (obs)
       real(r_single), dimension(:), allocatable    :: Errinv_Input                      !  (obs)

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_mandlev.fd/grads_mandlev.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_mandlev.fd/grads_mandlev.f90
@@ -7,7 +7,7 @@
 !-------------------------------------------------------------
 
 subroutine grads_mandlev(fileo,ifileo,nobs,nreal,nlev,plev,iscater,igrads,&
-                isubtype,subtype,list,run)
+                subtype,list,run)
 
    use generic_list
    use data
@@ -15,6 +15,7 @@ subroutine grads_mandlev(fileo,ifileo,nobs,nreal,nlev,plev,iscater,igrads,&
    implicit none
 
    external :: rm_dups
+   external :: getlev
 
    type(list_node_t), pointer   :: list
    type(list_node_t), pointer   :: next => null()
@@ -38,7 +39,6 @@ subroutine grads_mandlev(fileo,ifileo,nobs,nreal,nlev,plev,iscater,igrads,&
 
    integer              :: i,j,ii,k,ctr,obs_ctr
    integer              :: ilat,ilon,ipres,itime,iweight,ndup
-   integer(4)           :: isubtype
  
    stid='        '
    nflag0=0

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_mandlev.fd/maingrads_mandlev.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_mandlev.fd/maingrads_mandlev.f90
@@ -16,14 +16,14 @@ program maingrads_mandlev
    interface
 
       subroutine grads_mandlev(fileo,ifileo,nobs,nreal,nlev,plev,iscater,igrads,&
-                isubtype,subtype,list,run)
+                subtype,list,run)
 
          use generic_list
 
          integer                :: ifileo
          character(ifileo)      :: fileo
          integer                        :: nobs,nreal,nlev
-         integer                        :: iscater,igrads,isubtype
+         integer                        :: iscater,igrads
          real(4),dimension(nlev)        :: plev
          character(3)                   :: subtype
          type(list_node_t), pointer     :: list
@@ -79,7 +79,7 @@ program maingrads_mandlev
 
    if( nobs > 0 ) then 
       call grads_mandlev(stype,lstype,nobs,nreal,n_mand,pmand,iscater,igrads,&
-                isubtype,subtype,list,run) 
+                subtype,list,run) 
    else
       print *, 'NOBS <= 0, NO OUTPUT GENERATED'
    end if

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfc.fd/conmon_read_diag.F90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfc.fd/conmon_read_diag.F90
@@ -159,7 +159,7 @@ module conmon_read_diag
 
       if ( netcdf ) then
          write(6,*) ' call nc read subroutine'
-         call read_diag_file_nc( input_file, return_all, ctype, intype, expected_nreal, nobs, in_subtype, list )
+         call read_diag_file_nc( input_file, return_all, ctype, intype, nobs, in_subtype, list )
       else
          call read_diag_file_bin( input_file,return_all, ctype, intype, expected_nreal,nobs,in_subtype, list )
       end if
@@ -205,7 +205,7 @@ module conmon_read_diag
       !
       if ( netcdf ) then
          write(6,*) ' call nc retrieve all routine'
-         call read_diag_file_nc( input_file, return_all, ctype, intype, expected_nreal, nobs, in_subtype, list )
+         call read_diag_file_nc( input_file, return_all, ctype, intype, nobs, in_subtype, list )
       else
          write(6,*) ' call bin retrieve all routine'
          call read_diag_file_bin( input_file,return_all, ctype, intype, expected_nreal,nobs,in_subtype, list )
@@ -221,13 +221,13 @@ module conmon_read_diag
    !
    !  NetCDF read routine
    !-------------------------------
-   subroutine read_diag_file_nc( input_file, return_all, ctype, intype, expected_nreal, nobs, in_subtype, list )
+   subroutine read_diag_file_nc( input_file, return_all, ctype, intype, nobs, in_subtype, list )
 
       !--- interface 
       character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
@@ -267,22 +267,22 @@ module conmon_read_diag
       select case ( trim( adjustl( ctype ) ) )
    
          case ( 'gps' ) 
-            call read_diag_file_gps_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_gps_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 'ps' ) 
-            call read_diag_file_ps_nc(  input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_ps_nc(  return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 'q' ) 
-            call read_diag_file_q_nc(   input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_q_nc(   return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 'sst' )
-            call read_diag_file_sst_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_sst_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 't' ) 
-            call read_diag_file_t_nc(   input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_t_nc(   return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 'uv' ) 
-            call read_diag_file_uv_nc(  input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_uv_nc(  return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case default
             print *, 'ERROR:  unmatched ctype :', ctype
@@ -315,14 +315,13 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for ps data types in netcdf files
    !
-   subroutine read_diag_file_ps_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
+   subroutine read_diag_file_ps_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
@@ -517,14 +516,13 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for q data types in netcdf files
    !
-   subroutine read_diag_file_q_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
+   subroutine read_diag_file_q_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
@@ -731,14 +729,13 @@ module conmon_read_diag
    !  NOTE2:  There are known discrepencies between the contents
    !          of sst obs in binary and NetCDF files. 
    !
-   subroutine read_diag_file_sst_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
+   subroutine read_diag_file_sst_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
@@ -960,14 +957,13 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for t data types in netcdf files
    !
-   subroutine read_diag_file_t_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
-  
-      !--- interface 
-      character(100), intent(in) :: input_file
+   subroutine read_diag_file_t_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
+
+      !--- interface
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
@@ -1009,11 +1005,9 @@ module conmon_read_diag
       print *, ' '
       print *, '      --> read_diag_file_t_nc'
 
-      print *, '            input_file = ', input_file
       print *, '            ftin       = ', ftin
       print *, '            ctype      = ', ctype
       print *, '            intype     = ', intype  
-      print *, '            expected_nreal = ', expected_nreal 
       print *, '            in_subtype = ', in_subtype
 
 
@@ -1197,14 +1191,13 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for uv data types in netcdf files
    !
-   subroutine read_diag_file_uv_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+   subroutine read_diag_file_uv_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
@@ -1427,14 +1420,13 @@ module conmon_read_diag
    !          in binary and NetCDF formatted diag files. See
    !          comments below.
    !
-   subroutine read_diag_file_gps_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
+   subroutine read_diag_file_gps_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
  
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
@@ -1454,14 +1446,14 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Latitude                          !  (obs)
       real(r_single), dimension(:), allocatable    :: Longitude                         !  (obs)
       real(r_single), dimension(:), allocatable    :: Incremental_Bending_Angle         !  (obs)
-      real(r_single), dimension(:), allocatable    :: Station_Elevation                 !  (obs)
+      !real(r_single), dimension(:), allocatable    :: Station_Elevation                 !  (obs)
       real(r_single), dimension(:), allocatable    :: Pressure                          !  (obs)
       real(r_single), dimension(:), allocatable    :: Height                            !  (obs)
       real(r_single), dimension(:), allocatable    :: Time                              !  (obs)
       real(r_single), dimension(:), allocatable    :: Model_Elevation                   !  (obs)
       real(r_single), dimension(:), allocatable    :: Setup_QC_Mark                     !  (obs)
       real(r_single), dimension(:), allocatable    :: Prep_Use_Flag                     !  (obs)
-      real(r_single), dimension(:), allocatable    :: Nonlinear_QC_Var_Jb               !  (obs)
+      !real(r_single), dimension(:), allocatable    :: Nonlinear_QC_Var_Jb               !  (obs)
       real(r_single), dimension(:), allocatable    :: Nonlinear_QC_Rel_Wgt              !  (obs)
       real(r_single), dimension(:), allocatable    :: Analysis_Use_Flag                 !  (obs)
       real(r_single), dimension(:), allocatable    :: Errinv_Input                      !  (obs)

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfc.fd/grads_sfc.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfc.fd/grads_sfc.f90
@@ -5,7 +5,7 @@
 !       horizontal GrADS data files.
 !------------------------------------------------------------------------
 
-subroutine grads_sfc(fileo,ifileo,nobs,nreal,iscater,igrads,isubtype,subtype,list,run)
+subroutine grads_sfc(fileo,ifileo,nobs,nreal,iscater,igrads,subtype,list,run)
 
    use generic_list
    use data
@@ -28,7 +28,6 @@ subroutine grads_sfc(fileo,ifileo,nobs,nreal,iscater,igrads,isubtype,subtype,lis
    integer nobs,nreal,nflg0,nlev0,iscater,igrads
    real(4) rtim,xlat0,xlon0,rlat,rlon
  
-   integer(4):: isubtype
    integer i,j,ilat,ilon,ipres,itime,iweight,ndup
 
    rtim=0.0

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfc.fd/maingrads_sfc.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfc.fd/maingrads_sfc.f90
@@ -16,12 +16,12 @@ program maingrads_sfc
    interface
 
       subroutine grads_sfc(fileo,ifileo,nobs,nreal,iscater,igrads,&
-                           isubtype, subtype, list, run)
+                           subtype, list, run)
          use generic_list
 
          integer ifileo
          character(ifileo)              :: fileo
-         integer                        :: nobs,nreal,iscater,igrads,isubtype
+         integer                        :: nobs,nreal,iscater,igrads
          character(3)                   :: subtype
          type(list_node_t), pointer     :: list
          character(3)                   :: run
@@ -57,7 +57,7 @@ program maingrads_sfc
 
  
    if( nobs > 0 ) then
-      call grads_sfc(stype,lstype,nobs,nreal,iscater,igrads,isubtype,subtype,list,run) 
+      call grads_sfc(stype,lstype,nobs,nreal,iscater,igrads,subtype,list,run) 
    else
       print *, 'NOBS <= 0, NO OUTPUT GENERATED'
    end if

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfctime.fd/conmon_read_diag.F90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfctime.fd/conmon_read_diag.F90
@@ -159,7 +159,7 @@ module conmon_read_diag
 
       if ( netcdf ) then
          write(6,*) ' call nc read subroutine'
-         call read_diag_file_nc( input_file, return_all, ctype, intype, expected_nreal, nobs, in_subtype, list )
+         call read_diag_file_nc( input_file, return_all, ctype, intype, nobs, in_subtype, list )
       else
          call read_diag_file_bin( input_file,return_all, ctype, intype, expected_nreal,nobs,in_subtype, list )
       end if
@@ -205,7 +205,7 @@ module conmon_read_diag
       !
       if ( netcdf ) then
          write(6,*) ' call nc retrieve all routine'
-         call read_diag_file_nc( input_file, return_all, ctype, intype, expected_nreal, nobs, in_subtype, list )
+         call read_diag_file_nc( input_file, return_all, ctype, intype, nobs, in_subtype, list )
       else
          write(6,*) ' call bin retrieve all routine'
          call read_diag_file_bin( input_file,return_all, ctype, intype, expected_nreal,nobs,in_subtype, list )
@@ -221,13 +221,13 @@ module conmon_read_diag
    !
    !  NetCDF read routine
    !-------------------------------
-   subroutine read_diag_file_nc( input_file, return_all, ctype, intype, expected_nreal, nobs, in_subtype, list )
+   subroutine read_diag_file_nc( input_file, return_all, ctype, intype, nobs, in_subtype, list )
 
       !--- interface 
       character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
@@ -267,22 +267,22 @@ module conmon_read_diag
       select case ( trim( adjustl( ctype ) ) )
    
          case ( 'gps' ) 
-            call read_diag_file_gps_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_gps_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 'ps' ) 
-            call read_diag_file_ps_nc(  input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_ps_nc(  return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 'q' ) 
-            call read_diag_file_q_nc(   input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_q_nc(   return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 'sst' )
-            call read_diag_file_sst_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_sst_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 't' ) 
-            call read_diag_file_t_nc(   input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_t_nc(   return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 'uv' ) 
-            call read_diag_file_uv_nc(  input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_uv_nc(  return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case default
             print *, 'ERROR:  unmatched ctype :', ctype
@@ -315,14 +315,13 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for ps data types in netcdf files
    !
-   subroutine read_diag_file_ps_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
+   subroutine read_diag_file_ps_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
@@ -517,14 +516,13 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for q data types in netcdf files
    !
-   subroutine read_diag_file_q_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
+   subroutine read_diag_file_q_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
@@ -731,14 +729,13 @@ module conmon_read_diag
    !  NOTE2:  There are known discrepencies between the contents
    !          of sst obs in binary and NetCDF files. 
    !
-   subroutine read_diag_file_sst_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
+   subroutine read_diag_file_sst_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
@@ -960,14 +957,13 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for t data types in netcdf files
    !
-   subroutine read_diag_file_t_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+   subroutine read_diag_file_t_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
@@ -1009,11 +1005,9 @@ module conmon_read_diag
       print *, ' '
       print *, '      --> read_diag_file_t_nc'
 
-      print *, '            input_file = ', input_file
       print *, '            ftin       = ', ftin
       print *, '            ctype      = ', ctype
       print *, '            intype     = ', intype  
-      print *, '            expected_nreal = ', expected_nreal 
       print *, '            in_subtype = ', in_subtype
 
 
@@ -1197,14 +1191,13 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for uv data types in netcdf files
    !
-   subroutine read_diag_file_uv_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+   subroutine read_diag_file_uv_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
@@ -1427,14 +1420,13 @@ module conmon_read_diag
    !          in binary and NetCDF formatted diag files. See
    !          comments below.
    !
-   subroutine read_diag_file_gps_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
+   subroutine read_diag_file_gps_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
  
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
@@ -1454,14 +1446,14 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Latitude                          !  (obs)
       real(r_single), dimension(:), allocatable    :: Longitude                         !  (obs)
       real(r_single), dimension(:), allocatable    :: Incremental_Bending_Angle         !  (obs)
-      real(r_single), dimension(:), allocatable    :: Station_Elevation                 !  (obs)
+      !real(r_single), dimension(:), allocatable    :: Station_Elevation                 !  (obs)
       real(r_single), dimension(:), allocatable    :: Pressure                          !  (obs)
       real(r_single), dimension(:), allocatable    :: Height                            !  (obs)
       real(r_single), dimension(:), allocatable    :: Time                              !  (obs)
       real(r_single), dimension(:), allocatable    :: Model_Elevation                   !  (obs)
       real(r_single), dimension(:), allocatable    :: Setup_QC_Mark                     !  (obs)
       real(r_single), dimension(:), allocatable    :: Prep_Use_Flag                     !  (obs)
-      real(r_single), dimension(:), allocatable    :: Nonlinear_QC_Var_Jb               !  (obs)
+      !real(r_single), dimension(:), allocatable    :: Nonlinear_QC_Var_Jb               !  (obs)
       real(r_single), dimension(:), allocatable    :: Nonlinear_QC_Rel_Wgt              !  (obs)
       real(r_single), dimension(:), allocatable    :: Analysis_Use_Flag                 !  (obs)
       real(r_single), dimension(:), allocatable    :: Errinv_Input                      !  (obs)
@@ -1689,7 +1681,6 @@ module conmon_read_diag
       character(8),allocatable,dimension(:)  :: cdiag 
 
       character(3)   :: dtype
-      character(10)  :: otype
 
       integer nchar,file_nreal,i,ii,mype,idate,iflag,file_itype
       integer lunin,file_subtype

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfctime.fd/grads_sfctime.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfctime.fd/grads_sfctime.f90
@@ -7,7 +7,7 @@
 !---------------------------------------------------------------------------------
 
 subroutine grads_sfctime(fileo,ifileo,nobs,nreal,nlev,plev,iscater,&
-                         igrads,isubtype,subtype,list,run)
+                         igrads,subtype,list,run)
 
    use generic_list
    use data
@@ -15,6 +15,7 @@ subroutine grads_sfctime(fileo,ifileo,nobs,nreal,nlev,plev,iscater,&
    implicit none
 
    external ::  rm_dups
+   external ::  getlev
 
    type(list_node_t), pointer   :: list
    type(list_node_t), pointer   :: next => null()
@@ -22,7 +23,6 @@ subroutine grads_sfctime(fileo,ifileo,nobs,nreal,nlev,plev,iscater,&
 
    integer, intent(in)          :: ifileo, nobs, nreal, nlev
    integer, intent(in)          :: iscater, igrads
-   integer(4), intent(in)       :: isubtype
    character(ifileo),intent(in) :: fileo
    character(3), intent(in)     :: run, subtype
 

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfctime.fd/maingrads_sfctime.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sfctime.fd/maingrads_sfctime.f90
@@ -17,13 +17,13 @@ program maingrads_sfctime
    interface
 
       subroutine grads_sfctime(fileo,ifileo,nobs,nreal,&
-                    nlev,plev,iscater,igrads,isubtype,subtype,list,run)
+                    nlev,plev,iscater,igrads,subtype,list,run)
 
          use generic_list
          integer                 :: ifileo,nobs,nreal,nlev 
          character(ifileo)       :: fileo
          real(4),dimension(nlev) :: plev
-         integer                 :: iscater,igrads,isubtype
+         integer                 :: iscater,igrads
          character(3)            :: subtype
          type(list_node_t),pointer   :: list
          character(3)            :: run
@@ -71,10 +71,10 @@ program maingrads_sfctime
 
       if( trim(timecard) == 'time11') then
          call grads_sfctime(stype,lstype,nobs,nreal,n_time11,&
-                            ptime11,iscater,igrads,isubtype,subtype, list, run) 
+                            ptime11,iscater,igrads,subtype, list, run) 
       else if( trim(timecard) == 'time7') then 
          call grads_sfctime(stype,lstype,nobs,nreal,n_time7,&
-                            ptime7,iscater,igrads,isubtype,subtype,list, run) 
+                            ptime7,iscater,igrads,subtype,list, run) 
       endif
    
    else

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sig.fd/grads_sig.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_grads_sig.fd/grads_sig.f90
@@ -13,6 +13,7 @@ subroutine grads_sig(fileo,ifileo,nobs,nreal,nlev,plev,iscater,igrads,isubtype,s
    implicit none
 
    external ::  rm_dups
+   external ::  getpro
 
    type(list_node_t), pointer   :: list
    type(list_node_t), pointer   :: next => null()

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_time.fd/conmon_read_diag.F90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_time.fd/conmon_read_diag.F90
@@ -161,7 +161,7 @@ module conmon_read_diag
 
       if ( netcdf ) then
          write(6,*) ' call nc read subroutine'
-         call read_diag_file_nc( input_file, return_all, ctype, intype, expected_nreal, nobs, in_subtype, list )
+         call read_diag_file_nc( input_file, return_all, ctype, intype, nobs, in_subtype, list )
       else
          call read_diag_file_bin( input_file,return_all, ctype, intype, expected_nreal,nobs,in_subtype, list )
       end if
@@ -207,7 +207,7 @@ module conmon_read_diag
       !
       if ( netcdf ) then
          write(6,*) ' call nc retrieve all routine'
-         call read_diag_file_nc( input_file, return_all, ctype, intype, expected_nreal, nobs, in_subtype, list )
+         call read_diag_file_nc( input_file, return_all, ctype, intype, nobs, in_subtype, list )
       else
          write(6,*) ' call bin retrieve all routine'
          call read_diag_file_bin( input_file,return_all, ctype, intype, expected_nreal,nobs,in_subtype, list )
@@ -223,13 +223,13 @@ module conmon_read_diag
    !
    !  NetCDF read routine
    !-------------------------------
-   subroutine read_diag_file_nc( input_file, return_all, ctype, intype, expected_nreal, nobs, in_subtype, list )
+   subroutine read_diag_file_nc( input_file, return_all, ctype, intype, nobs, in_subtype, list )
 
       !--- interface 
       character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
@@ -269,22 +269,22 @@ module conmon_read_diag
       select case ( trim( adjustl( ctype ) ) )
    
          case ( 'gps' ) 
-            call read_diag_file_gps_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_gps_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 'ps' ) 
-            call read_diag_file_ps_nc(  input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_ps_nc(  return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 'q' ) 
-            call read_diag_file_q_nc(   input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_q_nc(   return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 'sst' )
-            call read_diag_file_sst_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_sst_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 't' ) 
-            call read_diag_file_t_nc(   input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_t_nc(   return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case ( 'uv' ) 
-            call read_diag_file_uv_nc(  input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+            call read_diag_file_uv_nc(  return_all, ftin, ctype, intype, nobs, in_subtype, list )
 
          case default
             print *, 'ERROR:  unmatched ctype :', ctype
@@ -317,21 +317,20 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for ps data types in netcdf files
    !
-   subroutine read_diag_file_ps_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
+   subroutine read_diag_file_ps_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx, id
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -367,7 +366,8 @@ module conmon_read_diag
       !
       if( nc_diag_read_check_dim( 'nobs' )) then
          total_obs = nc_diag_read_get_dim(ftin,'nobs')
-         ncdiag_open_status(ii)%num_records = total_obs
+         id = find_ncdiag_id(ftin)
+         ncdiag_open_status(id)%num_records = total_obs
          print *, '          total_obs = ', total_obs
       else
          print *, 'ERROR:  unable to read nobs'
@@ -519,21 +519,20 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for q data types in netcdf files
    !
-   subroutine read_diag_file_q_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
+   subroutine read_diag_file_q_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx, id
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -570,7 +569,8 @@ module conmon_read_diag
       !
       if( nc_diag_read_check_dim( 'nobs' )) then
          total_obs = nc_diag_read_get_dim(ftin,'nobs')
-         ncdiag_open_status(ii)%num_records = total_obs
+         id = find_ncdiag_id(ftin)
+         ncdiag_open_status(id)%num_records = total_obs
          print *, '          total_obs = ', total_obs
       else
          print *, 'ERROR:  unable to read nobs'
@@ -733,21 +733,20 @@ module conmon_read_diag
    !  NOTE2:  There are known discrepencies between the contents
    !          of sst obs in binary and NetCDF files. 
    !
-   subroutine read_diag_file_sst_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
+   subroutine read_diag_file_sst_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx, id
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -787,7 +786,8 @@ module conmon_read_diag
       !
       if( nc_diag_read_check_dim( 'nobs' )) then
          total_obs = nc_diag_read_get_dim(ftin,'nobs')
-         ncdiag_open_status(ii)%num_records = total_obs
+         id = find_ncdiag_id(ftin)
+         ncdiag_open_status(id)%num_records = total_obs
          print *, '          total_obs = ', total_obs
       else
          print *, 'ERROR:  unable to read nobs'
@@ -962,21 +962,20 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for t data types in netcdf files
    !
-   subroutine read_diag_file_t_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+   subroutine read_diag_file_t_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, total_obs, idx, bcor_terms
+      integer                    :: ii, ierr, total_obs, idx, bcor_terms, id
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1011,11 +1010,9 @@ module conmon_read_diag
       print *, ' '
       print *, '      --> read_diag_file_t_nc'
 
-      print *, '            input_file = ', input_file
       print *, '            ftin       = ', ftin
       print *, '            ctype      = ', ctype
       print *, '            intype     = ', intype  
-      print *, '            expected_nreal = ', expected_nreal 
       print *, '            in_subtype = ', in_subtype
 
 
@@ -1023,7 +1020,8 @@ module conmon_read_diag
       !
       if( nc_diag_read_check_dim( 'nobs' )) then
          total_obs = nc_diag_read_get_dim(ftin,'nobs')
-         ncdiag_open_status(ii)%num_records = total_obs
+         id = find_ncdiag_id(ftin)
+         ncdiag_open_status(id)%num_records = total_obs
       else
          print *, 'ERROR:  unable to read nobs'
          ierr=1
@@ -1199,21 +1197,20 @@ module conmon_read_diag
    !--------------------------------------------------------- 
    !  netcdf read routine for uv data types in netcdf files
    !
-   subroutine read_diag_file_uv_nc( input_file, return_all, ftin, ctype, intype, expected_nreal, nobs, in_subtype, list )
+   subroutine read_diag_file_uv_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
   
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx, id
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1254,7 +1251,8 @@ module conmon_read_diag
       !
       if( nc_diag_read_check_dim( 'nobs' )) then
          total_obs = nc_diag_read_get_dim(ftin,'nobs')
-         ncdiag_open_status(ii)%num_records = total_obs
+         id = find_ncdiag_id(ftin)
+         ncdiag_open_status(id)%num_records = total_obs
          print *, '          total_obs = ', total_obs
       else
          print *, 'ERROR:  unable to read nobs'
@@ -1429,21 +1427,20 @@ module conmon_read_diag
    !          in binary and NetCDF formatted diag files. See
    !          comments below.
    !
-   subroutine read_diag_file_gps_nc( input_file, return_all, ftin, ctype, intype,expected_nreal,nobs,in_subtype, list )
+   subroutine read_diag_file_gps_nc( return_all, ftin, ctype, intype, nobs, in_subtype, list )
  
       !--- interface 
-      character(100), intent(in) :: input_file
       logical, intent(in)        :: return_all
       integer, intent(in)        :: ftin
       character(3), intent(in)   :: ctype
-      integer, intent(in)        :: intype, expected_nreal, in_subtype
+      integer, intent(in)        :: intype, in_subtype
       integer, intent(out)       :: nobs
       type(list_node_t), pointer :: list
 
       !--- local vars
       type(list_node_t), pointer :: next => null()
       type(data_ptr)             :: ptr
-      integer                    :: ii, ierr, total_obs, idx
+      integer                    :: ii, ierr, total_obs, idx, id
       logical                    :: have_subtype = .true.
       logical                    :: add_obs
 
@@ -1456,14 +1453,14 @@ module conmon_read_diag
       real(r_single), dimension(:), allocatable    :: Latitude                          !  (obs)
       real(r_single), dimension(:), allocatable    :: Longitude                         !  (obs)
       real(r_single), dimension(:), allocatable    :: Incremental_Bending_Angle         !  (obs)
-      real(r_single), dimension(:), allocatable    :: Station_Elevation                 !  (obs)
+      !real(r_single), dimension(:), allocatable    :: Station_Elevation                 !  (obs)
       real(r_single), dimension(:), allocatable    :: Pressure                          !  (obs)
       real(r_single), dimension(:), allocatable    :: Height                            !  (obs)
       real(r_single), dimension(:), allocatable    :: Time                              !  (obs)
       real(r_single), dimension(:), allocatable    :: Model_Elevation                   !  (obs)
       real(r_single), dimension(:), allocatable    :: Setup_QC_Mark                     !  (obs)
       real(r_single), dimension(:), allocatable    :: Prep_Use_Flag                     !  (obs)
-      real(r_single), dimension(:), allocatable    :: Nonlinear_QC_Var_Jb               !  (obs)
+      !real(r_single), dimension(:), allocatable    :: Nonlinear_QC_Var_Jb               !  (obs)
       real(r_single), dimension(:), allocatable    :: Nonlinear_QC_Rel_Wgt              !  (obs)
       real(r_single), dimension(:), allocatable    :: Analysis_Use_Flag                 !  (obs)
       real(r_single), dimension(:), allocatable    :: Errinv_Input                      !  (obs)
@@ -1485,7 +1482,8 @@ module conmon_read_diag
       !
       if( nc_diag_read_check_dim( 'nobs' )) then
          total_obs = nc_diag_read_get_dim(ftin,'nobs')
-         ncdiag_open_status(ii)%num_records = total_obs
+         id = find_ncdiag_id(ftin)
+         ncdiag_open_status(id)%num_records = total_obs
          print *, '          total_obs = ', total_obs
       else
          print *, 'ERROR:  unable to read nobs'

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_time.fd/mainconv_time.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_time.fd/mainconv_time.f90
@@ -108,16 +108,16 @@
                  iosubtype_ps,iosubtype_q,iosubtype_t,iosubtype_uv, iosubtype_gps) 
    
 
-   call creatstas_ctl(dtype_ps,iotype_ps,ituse_ps,100,ntype_ps,1,nregion,18,region,&
+   call creatstas_ctl(dtype_ps,iotype_ps,ituse_ps,ntype_ps,1,nregion,18,region,&
                      rlatmin,rlatmax,rlonmin,rlonmax,iosubtype_ps) 
-   call creatstas_ctl(dtype_q,iotype_q,ituse_q,100,ntype_q,np,nregion,18,region,&
+   call creatstas_ctl(dtype_q,iotype_q,ituse_q,ntype_q,np,nregion,18,region,&
                      rlatmin,rlatmax,rlonmin,rlonmax,iosubtype_q) 
-   call creatstas_ctl(dtype_t,iotype_t,ituse_t,100,ntype_t,np,nregion,18,&
+   call creatstas_ctl(dtype_t,iotype_t,ituse_t,ntype_t,np,nregion,18,&
                      region,rlatmin,rlatmax,rlonmin,rlonmax,iosubtype_t) 
-   call creatstas_ctl(dtype_uv,iotype_uv,ituse_uv,100,ntype_uv,np,nregion,18,&
+   call creatstas_ctl(dtype_uv,iotype_uv,ituse_uv,ntype_uv,np,nregion,18,&
                      region,rlatmin,rlatmax,rlonmin,rlonmax,iosubtype_uv) 
 
-   call creatstas_ctl(dtype_gps,iotype_gps,ituse_gps,100,ntype_gps,np,nregion,18,region,&
+   call creatstas_ctl(dtype_gps,iotype_gps,ituse_gps,ntype_gps,np,nregion,18,region,&
                      rlatmin,rlatmax,rlonmin,rlonmax,iosubtype_gps) 
 
    stop

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_time.fd/process_time_data.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_time.fd/process_time_data.f90
@@ -39,13 +39,26 @@ module conmon_process_time_data
    use ncdr_vars, only:    nc_diag_read_check_var
 
    use conmon_read_diag
- 
+   use stas_time_mod, only: stascal
  
    !--- implicit ---!
    implicit none
 
-   external ::  stascal
-   external ::  stascal_gps
+   interface
+      subroutine stascal_gps(rdiag,nreal,n,iotype,varqc,ntype,work,&
+                   np,htop,hbot,nregion,mregion,&
+                   rlatmin,rlatmax,rlonmin,rlonmax,iosubtype)
+         implicit none
+         character(3) :: dtype
+         integer :: nreal,n,ntype,np,nregion,mregion
+         real(4),dimension(nreal,n) :: rdiag
+         integer,dimension(:) :: iotype,iosubtype
+         real(4),dimension(:,:) :: varqc
+         real(4),dimension(:,:,:,:,:) :: work
+         real(4),dimension(np) :: htop,hbot
+         real(4),dimension(mregion):: rlatmin,rlatmax,rlonmin,rlonmax
+      end subroutine stascal_gps
+   end interface
 
    !--- public & private ---!
    private 
@@ -96,23 +109,50 @@ module conmon_process_time_data
       integer                     mregion,nregion,np
       real(4),dimension(np)    :: ptop,pbot,ptopq,pbotq,htop_gps,hbot_gps
       real,dimension(mregion)  :: rlatmin,rlatmax,rlonmin,rlonmax
-      integer,dimension(100)   :: iotype_ps,iotype_q,iotype_t,iotype_uv,iotype_gps
-      real(4),dimension(100,2) :: varqc_ps,varqc_q,varqc_t,varqc_uv,varqc_gps
+      integer,dimension(:)     :: iotype_ps,iotype_q,iotype_t,iotype_uv,iotype_gps
+      real(4),dimension(:,:)   :: varqc_ps,varqc_q,varqc_t,varqc_uv,varqc_gps
       integer                     ntype_ps,ntype_q,ntype_t,ntype_uv,ntype_gps
-      integer,dimension(100)   :: iosubtype_ps,iosubtype_q,iosubtype_t,iosubtype_uv, iosubtype_gps
+      integer,dimension(:)     :: iosubtype_ps,iosubtype_q,iosubtype_t,iosubtype_uv, iosubtype_gps
+      integer                     ntype_ps_use,ntype_q_use,ntype_t_use,ntype_uv_use,ntype_gps_use
+      integer                     ntype_ps_dim,ntype_q_dim,ntype_t_dim,ntype_uv_dim,ntype_gps_dim
 
-      real(4),dimension(np,100,6,nregion,3)  :: twork,qwork,uwork,vwork,uvwork
-      real(4),dimension(1,100,6,nregion,3)   :: pswork
+      real(4),allocatable,dimension(:,:,:,:,:)  :: twork,qwork,uwork,vwork,uvwork
+      real(4),allocatable,dimension(:,:,:,:,:)  :: pswork
+
+        ! Arrays are dimensioned to 100 in the type slot and use ntype+1 for totals,
+        ! so the maximum safe number of concrete types is 99.
+      ntype_ps_use  = max( 0, min( ntype_ps,  min(size(iotype_ps), min(size(iosubtype_ps), size(varqc_ps,1))) ))
+      ntype_q_use   = max( 0, min( ntype_q,   min(size(iotype_q),  min(size(iosubtype_q),  size(varqc_q,1))) ))
+      ntype_t_use   = max( 0, min( ntype_t,   min(size(iotype_t),  min(size(iosubtype_t),  size(varqc_t,1))) ))
+      ntype_uv_use  = max( 0, min( ntype_uv,  min(size(iotype_uv), min(size(iosubtype_uv), size(varqc_uv,1))) ))
+      ntype_gps_use = max( 0, min( ntype_gps, min(size(iotype_gps),min(size(iosubtype_gps),size(varqc_gps,1))) ))
+
+      ntype_ps_dim  = max( 1, ntype_ps_use + 1 )
+      ntype_q_dim   = max( 1, ntype_q_use  + 1 )
+      ntype_t_dim   = max( 1, ntype_t_use  + 1 )
+      ntype_uv_dim  = max( 1, ntype_uv_use + 1 )
+      ntype_gps_dim = max( 1, ntype_gps_use+ 1 )
+
+      if( ntype_ps_use /= ntype_ps .or. ntype_q_use /= ntype_q .or. ntype_t_use /= ntype_t .or. &
+           ntype_uv_use /= ntype_uv .or. ntype_gps_use /= ntype_gps ) then
+         write(6,*) 'WARNING: ntype exceeds available metadata array sizes; truncating where needed.'
+          write(6,*) 'ntype_ps, ntype_q, ntype_t, ntype_uv, ntype_gps = ', &
+                  ntype_ps_use, ntype_q_use, ntype_t_use, ntype_uv_use, ntype_gps_use
+        end if
+
+      allocate( twork(np,ntype_t_dim,6,nregion,3), qwork(np,ntype_q_dim,6,nregion,3), &
+                uwork(np,ntype_uv_dim,6,nregion,3), vwork(np,ntype_uv_dim,6,nregion,3), &
+                uvwork(np,ntype_uv_dim,6,nregion,3), pswork(1,ntype_ps_dim,6,nregion,3) )
 
       write(6,*) 'input_file = ', input_file
 
       if( netcdf ) then
          write(6,*) ' call nc read subroutine'
-         call process_conv_nc( input_file, ctype, mregion,nregion,np,ptop,pbot,ptopq,pbotq,&
+         call process_conv_nc( input_file, ctype, mregion,nregion,np,ptop,pbot,&
                                htop_gps, hbot_gps,&
                  rlatmin,rlatmax,rlonmin,rlonmax,iotype_ps,iotype_q,&
                  iotype_t,iotype_uv,iotype_gps,varqc_ps,varqc_q,varqc_t,varqc_uv,varqc_gps,&
-                 ntype_ps,ntype_q,ntype_t,ntype_uv,ntype_gps,&
+                 ntype_ps_use,ntype_q_use,ntype_t_use,ntype_uv_use,ntype_gps_use,&
                  iosubtype_ps,iosubtype_q,iosubtype_t,iosubtype_uv,iosubtype_gps,&
                  twork,uwork,vwork,uvwork )
       else
@@ -120,13 +160,20 @@ module conmon_process_time_data
          call process_conv_bin( input_file,mregion,nregion,np,ptop,pbot,ptopq,pbotq,&
                  rlatmin,rlatmax,rlonmin,rlonmax,iotype_ps,iotype_q,&
                  iotype_t,iotype_uv,varqc_ps,varqc_q,varqc_t,varqc_uv,&
-                 ntype_ps,ntype_q,ntype_t,ntype_uv,&
+                  ntype_ps_use,ntype_q_use,ntype_t_use,ntype_uv_use,&
                  iosubtype_ps,iosubtype_q,iosubtype_t,iosubtype_uv, &
                  twork,qwork,uwork,vwork,uvwork, pswork )
 
          call output_data( twork, qwork, uwork, vwork, uvwork, pswork, &
-                        ntype_ps, ntype_q, ntype_t, ntype_uv, nregion, np )
+                     ntype_ps_use, ntype_q_use, ntype_t_use, ntype_uv_use, nregion, np )
       end if 
+
+         if( allocated(twork) ) deallocate(twork)
+         if( allocated(qwork) ) deallocate(qwork)
+         if( allocated(uwork) ) deallocate(uwork)
+         if( allocated(vwork) ) deallocate(vwork)
+         if( allocated(uvwork) ) deallocate(uvwork)
+         if( allocated(pswork) ) deallocate(pswork)
 
 
    end subroutine process_conv_diag
@@ -155,13 +202,13 @@ module conmon_process_time_data
       integer, intent(in)                    :: np
       real(4),dimension(np),intent(in)       :: ptop,pbot,ptopq,pbotq
       real,dimension(mregion),intent(in)     :: rlatmin,rlatmax,rlonmin,rlonmax
-      integer,dimension(100),intent(in)      :: iotype_ps,iotype_q,iotype_t,iotype_uv
-      real(4),dimension(100,2),intent(in)    :: varqc_ps,varqc_q,varqc_t,varqc_uv
+      integer,dimension(:),intent(in)        :: iotype_ps,iotype_q,iotype_t,iotype_uv
+      real(4),dimension(:,:),intent(in)      :: varqc_ps,varqc_q,varqc_t,varqc_uv
       integer, intent(in)                    :: ntype_ps,ntype_q,ntype_t
-      integer,dimension(100),intent(in)      :: iosubtype_ps,iosubtype_q,iosubtype_uv,iosubtype_t
+      integer,dimension(:),intent(in)        :: iosubtype_ps,iosubtype_q,iosubtype_uv,iosubtype_t
 
-      real(4),dimension(np,100,6,nregion,3), intent(out)  :: twork,qwork,uwork,vwork,uvwork
-      real(4),dimension(1,100,6,nregion,3), intent(out)   :: pswork
+      real(4),dimension(:,:,:,:,:), intent(out)           :: twork,qwork,uwork,vwork,uvwork
+      real(4),dimension(:,:,:,:,:), intent(out)           :: pswork
 
 
 
@@ -249,7 +296,7 @@ module conmon_process_time_data
    !  tar file contains 4 ges and 4 anl diag files.
    !-----------------------------------------------------------
    subroutine process_conv_nc( input_file, ctype, mregion, nregion, np, &
-           ptop, pbot, ptopq, pbotq, htop_gps, hbot_gps, rlatmin, rlatmax, rlonmin, rlonmax, &
+           ptop, pbot, htop_gps, hbot_gps, rlatmin, rlatmax, rlonmin, rlonmax, &
            iotype_ps, iotype_q, iotype_t, iotype_uv, iotype_gps, varqc_ps, varqc_q, &
            varqc_t, varqc_uv, varqc_gps, ntype_ps, ntype_q, ntype_t, ntype_uv, ntype_gps,&
            iosubtype_ps, iosubtype_q, iosubtype_t, iosubtype_uv, iosubtype_gps,&
@@ -266,21 +313,21 @@ module conmon_process_time_data
       integer, intent(in)                    :: mregion
       integer, intent(in)                    :: nregion
       integer, intent(in)                    :: np
-      real(4),dimension(np),intent(in)       :: ptop,pbot,ptopq,pbotq,htop_gps,hbot_gps
+      real(4),dimension(np),intent(in)       :: ptop,pbot,htop_gps,hbot_gps
       real,dimension(mregion),intent(in)     :: rlatmin,rlatmax,rlonmin,rlonmax
-      integer,dimension(100),intent(in)      :: iotype_ps,iotype_q,iotype_t,iotype_uv,iotype_gps
-      real(4),dimension(100,2),intent(in)    :: varqc_ps,varqc_q,varqc_t,varqc_uv,varqc_gps
+      integer,dimension(:),intent(in)        :: iotype_ps,iotype_q,iotype_t,iotype_uv,iotype_gps
+      real(4),dimension(:,:),intent(in)      :: varqc_ps,varqc_q,varqc_t,varqc_uv,varqc_gps
       integer, intent(in)                    :: ntype_uv,ntype_ps,ntype_q,ntype_t,ntype_gps
-      integer,dimension(100),intent(in)      :: iosubtype_ps,iosubtype_q,iosubtype_uv,iosubtype_t,iosubtype_gps
+      integer,dimension(:),intent(in)        :: iosubtype_ps,iosubtype_q,iosubtype_uv,iosubtype_t,iosubtype_gps
 
       !========================================================================
       !  NOTE:  I think the *work arrays don't need to be params -- they are
       !  just used here and can then be deallocated w/o issue.
       !========================================================================
       
-      real(4),dimension(np,100,6,nregion,3), intent(out)  :: twork,uwork,vwork,uvwork
-      real(4),dimension(np,100,6,nregion,3)  :: qwork, gpswork
-      real(4),dimension(1,100,6,nregion,3)   :: pswork
+      real(4),dimension(:,:,:,:,:), intent(out)           :: twork,uwork,vwork
+      real(4),dimension(:,:,:,:,:), intent(out)           :: uvwork
+      real(4),allocatable,dimension(:,:,:,:,:)            :: qwork, gpswork, pswork
 
 
       type(list_node_t), pointer             :: list => null()
@@ -296,6 +343,9 @@ module conmon_process_time_data
       print *, '--> process_conv_nc'
       print *, '      input_file = ', input_file
       print *, '      ctype      = ', ctype     
+
+      allocate( qwork(np,max(1,ntype_q+1),6,nregion,3), gpswork(np,max(1,ntype_gps+1),6,nregion,3), &
+             pswork(1,max(1,ntype_ps+1),6,nregion,3) )
 
       twork=0.0; qwork=0.0; uwork=0.0; vwork=0.0; uvwork=0.0; pswork=0.0; gpswork=0.0
 
@@ -334,7 +384,7 @@ module conmon_process_time_data
 
             print *, 'found nobs in list = ', obs_ctr
 
-            call output_data_ps( pswork, ntype_ps, nregion, 1 )
+            call output_data_ps( pswork, ntype_ps, nregion )
 
          case ( 'q' )
             print *, ' select, case q'
@@ -426,7 +476,7 @@ module conmon_process_time_data
             print *, 'found nobs in list = ', obs_ctr
             call list_free( list )
       
-            call stascal_gps(ctype, rdiag, max_rdiag_reals, nobs, iotype_gps, varqc_gps, ntype_gps, &
+            call stascal_gps(rdiag, max_rdiag_reals, nobs, iotype_gps, varqc_gps, ntype_gps, &
                          gpswork, np, htop_gps, hbot_gps, nregion, mregion, &
                          rlatmin, rlatmax, rlonmin, rlonmax, iosubtype_gps)
 
@@ -436,6 +486,9 @@ module conmon_process_time_data
 
 
       if( allocated( rdiag )) deallocate( rdiag )
+      if( allocated( qwork )) deallocate( qwork )
+      if( allocated( gpswork )) deallocate( gpswork )
+      if( allocated( pswork )) deallocate( pswork )
 
       print *, '<-- process_conv_nc'
 
@@ -443,10 +496,10 @@ module conmon_process_time_data
 
 
 
-   subroutine output_data_ps( pswork, ntype_ps, nregion, np )
+   subroutine output_data_ps( pswork, ntype_ps, nregion )
 
-      real(4),dimension(1,100,6,nregion,3), intent(inout)   :: pswork
-      integer, intent(in)                                   :: ntype_ps, nregion, np
+      real(4),dimension(:,:,:,:,:), intent(inout)            :: pswork
+      integer, intent(in)                                   :: ntype_ps, nregion
 
       integer                                               :: ii, jj, ltype, iregion
       integer, parameter                                    :: outfile = 21
@@ -476,7 +529,7 @@ module conmon_process_time_data
                   pswork(1,ltype,3,iregion,jj)= &
                         pswork(1,ltype,3,iregion,jj)/pswork(1,ltype,1,iregion,jj)
                   pswork(1,ltype,4,iregion,jj)= &
-                        sqrt(pswork(1,ltype,4,iregion,jj)/pswork(1,ltype,1,iregion,jj))
+                        sqrt(max(0.0, pswork(1,ltype,4,iregion,jj))/pswork(1,ltype,1,iregion,jj))
                   pswork(1,ltype,5,iregion,jj)= &
                         pswork(1,ltype,5,iregion,jj)/pswork(1,ltype,1,iregion,jj)
                   pswork(1,ltype,6,iregion,jj)= &
@@ -490,7 +543,7 @@ module conmon_process_time_data
             if(pswork(1,ntype_ps+1,1,iregion,jj) >=1.0) then
                pswork(1,ntype_ps+1,3,iregion,jj) = pswork(1,ntype_ps+1,3,iregion,jj)/&
                                        pswork(1,ntype_ps+1,1,iregion,jj)
-               pswork(1,ntype_ps+1,4,iregion,jj) = sqrt(pswork(1,ntype_ps+1,4,iregion,jj)&
+               pswork(1,ntype_ps+1,4,iregion,jj) = sqrt(max(0.0, pswork(1,ntype_ps+1,4,iregion,jj))&
                                     /pswork(1,ntype_ps+1,1,iregion,jj))
                pswork(1,ntype_ps+1,5,iregion,jj) = pswork(1,ntype_ps+1,5,iregion,jj)/&
                                     pswork(1,ntype_ps+1,1,iregion,jj)
@@ -518,7 +571,7 @@ module conmon_process_time_data
 
    subroutine output_data_q( qwork, ntype_q, nregion, np )
 
-      real(4),dimension(np,100,6,nregion,3), intent(inout)  :: qwork
+      real(4),dimension(:,:,:,:,:), intent(inout)           :: qwork
       integer, intent(in)                                   :: ntype_q, nregion, np
 
       integer                                               :: ii, jj, kk, ltype, iregion
@@ -546,7 +599,7 @@ module conmon_process_time_data
                      qwork(kk,ltype,3,iregion,jj) = &
                            qwork(kk,ltype,3,iregion,jj)/qwork(kk,ltype,1,iregion,jj)
                      qwork(kk,ltype,4,iregion,jj) = &
-                           sqrt(qwork(kk,ltype,4,iregion,jj)/qwork(kk,ltype,1,iregion,jj))
+                           sqrt(max(0.0, qwork(kk,ltype,4,iregion,jj))/qwork(kk,ltype,1,iregion,jj))
                      qwork(kk,ltype,5,iregion,jj) = &
                            qwork(kk,ltype,5,iregion,jj)/qwork(kk,ltype,1,iregion,jj)
                      qwork(kk,ltype,6,iregion,jj) = &
@@ -557,7 +610,7 @@ module conmon_process_time_data
                if(qwork(kk,ntype_q+1,1,iregion,jj) >=1.0) then
                   qwork(kk,ntype_q+1,3,iregion,jj)=qwork(kk,ntype_q+1,3,iregion,jj)/&
                                     qwork(kk,ntype_q+1,1,iregion,jj)
-                  qwork(kk,ntype_q+1,4,iregion,jj)=sqrt(qwork(kk,ntype_q+1,4,iregion,jj)/&
+                  qwork(kk,ntype_q+1,4,iregion,jj)=sqrt(max(0.0,qwork(kk,ntype_q+1,4,iregion,jj))/&
                                     qwork(kk,ntype_q+1,1,iregion,jj))
                   qwork(kk,ntype_q+1,5,iregion,jj)=qwork(kk,ntype_q+1,5,iregion,jj)/&
                                     qwork(kk,ntype_q+1,1,iregion,jj)
@@ -592,7 +645,7 @@ module conmon_process_time_data
 
    subroutine output_data_t( twork, ntype_t, nregion, np )
 
-      real(4),dimension(np,100,6,nregion,3), intent(inout)  :: twork
+      real(4),dimension(:,:,:,:,:), intent(inout)           :: twork
       integer, intent(in)                                   :: ntype_t, nregion, np
 
       integer                                               :: ii, jj, kk, ltype, iregion
@@ -621,7 +674,7 @@ module conmon_process_time_data
                      twork(kk,ltype,3,iregion,jj) = &
                            twork(kk,ltype,3,iregion,jj)/twork(kk,ltype,1,iregion,jj)
                      twork(kk,ltype,4,iregion,jj) = &
-                           sqrt(twork(kk,ltype,4,iregion,jj)/twork(kk,ltype,1,iregion,jj))
+                           sqrt(max(0.0, twork(kk,ltype,4,iregion,jj))/twork(kk,ltype,1,iregion,jj))
                      twork(kk,ltype,5,iregion,jj) = &
                            twork(kk,ltype,5,iregion,jj)/twork(kk,ltype,1,iregion,jj)
                      twork(kk,ltype,6,iregion,jj) = &
@@ -632,7 +685,7 @@ module conmon_process_time_data
                if(twork(kk,ntype_t+1,1,iregion,jj) >=1.0) then
                   twork(kk,ntype_t+1,3,iregion,jj) = twork(kk,ntype_t+1,3,iregion,jj)/&
                                     twork(kk,ntype_t+1,1,iregion,jj)
-                  twork(kk,ntype_t+1,4,iregion,jj)=sqrt(twork(kk,ntype_t+1,4,iregion,jj)/&
+                  twork(kk,ntype_t+1,4,iregion,jj)=sqrt(max(0.0, twork(kk,ntype_t+1,4,iregion,jj))/&
                                     twork(kk,ntype_t+1,1,iregion,jj))
                   twork(kk,ntype_t+1,5,iregion,jj)=twork(kk,ntype_t+1,5,iregion,jj)/&
                                     twork(kk,ntype_t+1,1,iregion,jj)
@@ -666,7 +719,7 @@ module conmon_process_time_data
 
    subroutine output_data_uv( uvwork, uwork, vwork, ntype_uv, nregion, np )
 
-      real(4),dimension(np,100,6,nregion,3), intent(inout)  :: uvwork, uwork, vwork
+      real(4),dimension(:,:,:,:,:), intent(inout)           :: uvwork, uwork, vwork
       integer, intent(in)                                   :: ntype_uv, nregion, np
 
       integer                                               :: ii, jj, kk, ltype, iregion
@@ -703,7 +756,7 @@ module conmon_process_time_data
                      uvwork(kk,ltype,3,iregion,jj) = &
                            uvwork(kk,ltype,3,iregion,jj)/uvwork(kk,ltype,1,iregion,jj)
                      uvwork(kk,ltype,4,iregion,jj) = &
-                           sqrt(uvwork(kk,ltype,4,iregion,jj)/uvwork(kk,ltype,1,iregion,jj))
+                           sqrt(max(0.0, uvwork(kk,ltype,4,iregion,jj))/uvwork(kk,ltype,1,iregion,jj))
                      uvwork(kk,ltype,5,iregion,jj) = &
                            uvwork(kk,ltype,5,iregion,jj)/uvwork(kk,ltype,1,iregion,jj)
                      uvwork(kk,ltype,6,iregion,jj) = &
@@ -715,18 +768,18 @@ module conmon_process_time_data
                      uwork(kk,ltype,3,iregion,jj) = &
                            uwork(kk,ltype,3,iregion,jj)/uvwork(kk,ltype,1,iregion,jj)
                      uwork(kk,ltype,4,iregion,jj) = &
-                           sqrt(uwork(kk,ltype,4,iregion,jj)/uvwork(kk,ltype,1,iregion,jj))
+                           sqrt(max(0.0, uwork(kk,ltype,4,iregion,jj))/uvwork(kk,ltype,1,iregion,jj))
                      vwork(kk,ltype,3,iregion,jj) = &
                            vwork(kk,ltype,3,iregion,jj)/uvwork(kk,ltype,1,iregion,jj)
                      vwork(kk,ltype,4,iregion,jj) = &
-                           sqrt(vwork(kk,ltype,4,iregion,jj)/uvwork(kk,ltype,1,iregion,jj))
+                           sqrt(max(0.0, vwork(kk,ltype,4,iregion,jj))/uvwork(kk,ltype,1,iregion,jj))
                   endif
                enddo
 
                if(uvwork(kk,ntype_uv+1,1,iregion,jj) >=1.0) then
                   uvwork(kk,ntype_uv+1,3,iregion,jj)=uvwork(kk,ntype_uv+1,3,iregion,jj)&
                                   /uvwork(kk,ntype_uv+1,1,iregion,jj)
-                  uvwork(kk,ntype_uv+1,4,iregion,jj)=sqrt(uvwork(kk,ntype_uv+1,4,iregion,jj)&
+                  uvwork(kk,ntype_uv+1,4,iregion,jj)=sqrt(max(0.0, uvwork(kk,ntype_uv+1,4,iregion,jj))&
                                   /uvwork(kk,ntype_uv+1,1,iregion,jj))
                   uvwork(kk,ntype_uv+1,5,iregion,jj)=uvwork(kk,ntype_uv+1,5,iregion,jj)&
                                   /uvwork(kk,ntype_uv+1,1,iregion,jj)
@@ -739,11 +792,11 @@ module conmon_process_time_data
    
                   uwork(kk,ntype_uv+1,3,iregion,jj)=uwork(kk,ntype_uv+1,3,iregion,jj)&
                                   /uwork(kk,ntype_uv+1,1,iregion,jj)
-                  uwork(kk,ntype_uv+1,4,iregion,jj)=sqrt(uwork(kk,ntype_uv+1,4,iregion,jj)&
+                  uwork(kk,ntype_uv+1,4,iregion,jj)=sqrt(max(0.0, uwork(kk,ntype_uv+1,4,iregion,jj))&
                                   /uwork(kk,ntype_uv+1,1,iregion,jj))
                   vwork(kk,ntype_uv+1,3,iregion,jj)=vwork(kk,ntype_uv+1,3,iregion,jj)&
                                   /vwork(kk,ntype_uv+1,1,iregion,jj)
-                  vwork(kk,ntype_uv+1,4,iregion,jj)=sqrt(vwork(kk,ntype_uv+1,4,iregion,jj)&
+                  vwork(kk,ntype_uv+1,4,iregion,jj)=sqrt(max(0.0, vwork(kk,ntype_uv+1,4,iregion,jj))&
                                   /vwork(kk,ntype_uv+1,1,iregion,jj))
                endif
    
@@ -788,9 +841,9 @@ module conmon_process_time_data
 
    subroutine output_data_gps( gpswork, ntype_gps, nregion, np, iotype_gps )
 
-      real(4),dimension(np,100,6,nregion,3), intent(inout)  :: gpswork
+      real(4),dimension(:,:,:,:,:), intent(inout)           :: gpswork
       integer, intent(in)                                   :: ntype_gps, nregion, np
-      integer,dimension(100), intent(in)                    :: iotype_gps
+      integer,dimension(:), intent(in)                      :: iotype_gps
       integer                                               :: ii, jj, kk, ltype, iregion
       integer, parameter                                    :: outfile = 61
       integer, parameter                                    :: nobsfile = 62
@@ -820,7 +873,7 @@ module conmon_process_time_data
                      gpswork(kk,ltype,3,iregion,jj) = &
                            gpswork(kk,ltype,3,iregion,jj)/gpswork(kk,ltype,1,iregion,jj)
                      gpswork(kk,ltype,4,iregion,jj) = &
-                           sqrt(gpswork(kk,ltype,4,iregion,jj)/gpswork(kk,ltype,1,iregion,jj))
+                           sqrt(max(0.0, gpswork(kk,ltype,4,iregion,jj))/gpswork(kk,ltype,1,iregion,jj))
                      gpswork(kk,ltype,5,iregion,jj) = &
                            gpswork(kk,ltype,5,iregion,jj)/gpswork(kk,ltype,1,iregion,jj)
                      gpswork(kk,ltype,6,iregion,jj) = &
@@ -831,7 +884,7 @@ module conmon_process_time_data
                if(gpswork(kk,ntype_gps+1,1,iregion,jj) >=1.0) then
                   gpswork(kk,ntype_gps+1,3,iregion,jj)=gpswork(kk,ntype_gps+1,3,iregion,jj)/&
                                     gpswork(kk,ntype_gps+1,1,iregion,jj)
-                  gpswork(kk,ntype_gps+1,4,iregion,jj)=sqrt(gpswork(kk,ntype_gps+1,4,iregion,jj)/&
+                  gpswork(kk,ntype_gps+1,4,iregion,jj)=sqrt(max(0.0, gpswork(kk,ntype_gps+1,4,iregion,jj))/&
                                     gpswork(kk,ntype_gps+1,1,iregion,jj))
                   gpswork(kk,ntype_gps+1,5,iregion,jj)=gpswork(kk,ntype_gps+1,5,iregion,jj)/&
                                     gpswork(kk,ntype_gps+1,1,iregion,jj)
@@ -892,8 +945,8 @@ module conmon_process_time_data
    subroutine output_data( twork, qwork, uwork, vwork, uvwork, pswork, &
                            ntype_ps, ntype_q, ntype_t, ntype_uv, nregion, np )
 
-      real(4),dimension(np,100,6,nregion,3), intent(inout)  :: twork,qwork,uwork,vwork,uvwork
-      real(4),dimension(1,100,6,nregion,3), intent(inout)   :: pswork
+      real(4),dimension(:,:,:,:,:), intent(inout)           :: twork,qwork,uwork,vwork,uvwork
+      real(4),dimension(:,:,:,:,:), intent(inout)           :: pswork
       integer, intent(in)                                   :: ntype_ps,ntype_q,ntype_t,ntype_uv,nregion,np
 
       integer                                               :: i,j,k,ltype,iregion
@@ -920,7 +973,7 @@ module conmon_process_time_data
                   pswork(1,ltype,3,iregion,j)= &
                         pswork(1,ltype,3,iregion,j)/pswork(1,ltype,1,iregion,j)
                   pswork(1,ltype,4,iregion,j)= &
-                        sqrt(pswork(1,ltype,4,iregion,j)/pswork(1,ltype,1,iregion,j))
+                        sqrt(max(0.0, pswork(1,ltype,4,iregion,j))/pswork(1,ltype,1,iregion,j))
                   pswork(1,ltype,5,iregion,j)= &
                         pswork(1,ltype,5,iregion,j)/pswork(1,ltype,1,iregion,j)
                   pswork(1,ltype,6,iregion,j)= &
@@ -934,7 +987,7 @@ module conmon_process_time_data
             if(pswork(1,ntype_ps+1,1,iregion,j) >=1.0) then
                pswork(1,ntype_ps+1,3,iregion,j) = pswork(1,ntype_ps+1,3,iregion,j)/&
                                        pswork(1,ntype_ps+1,1,iregion,j)
-               pswork(1,ntype_ps+1,4,iregion,j) = sqrt(pswork(1,ntype_ps+1,4,iregion,j)&
+               pswork(1,ntype_ps+1,4,iregion,j) = sqrt(max(0.0, pswork(1,ntype_ps+1,4,iregion,j))&
                                     /pswork(1,ntype_ps+1,1,iregion,j))
                pswork(1,ntype_ps+1,5,iregion,j) = pswork(1,ntype_ps+1,5,iregion,j)/&
                                     pswork(1,ntype_ps+1,1,iregion,j)
@@ -961,7 +1014,7 @@ module conmon_process_time_data
                      qwork(k,ltype,3,iregion,j) = &
                            qwork(k,ltype,3,iregion,j)/qwork(k,ltype,1,iregion,j)
                      qwork(k,ltype,4,iregion,j) = &
-                           sqrt(qwork(k,ltype,4,iregion,j)/qwork(k,ltype,1,iregion,j))
+                           sqrt(max(0.0, qwork(k,ltype,4,iregion,j))/qwork(k,ltype,1,iregion,j))
                      qwork(k,ltype,5,iregion,j) = &
                            qwork(k,ltype,5,iregion,j)/qwork(k,ltype,1,iregion,j)
                      qwork(k,ltype,6,iregion,j) = &
@@ -972,7 +1025,7 @@ module conmon_process_time_data
                if(qwork(k,ntype_q+1,1,iregion,j) >=1.0) then
                   qwork(k,ntype_q+1,3,iregion,j)=qwork(k,ntype_q+1,3,iregion,j)/&
                                     qwork(k,ntype_q+1,1,iregion,j)
-                  qwork(k,ntype_q+1,4,iregion,j)=sqrt(qwork(k,ntype_q+1,4,iregion,j)/&
+                  qwork(k,ntype_q+1,4,iregion,j)=sqrt(max(0.0, qwork(k,ntype_q+1,4,iregion,j))/&
                                     qwork(k,ntype_q+1,1,iregion,j))
                   qwork(k,ntype_q+1,5,iregion,j)=qwork(k,ntype_q+1,5,iregion,j)/&
                                     qwork(k,ntype_q+1,1,iregion,j)
@@ -998,7 +1051,7 @@ module conmon_process_time_data
                      twork(k,ltype,3,iregion,j) = &
                            twork(k,ltype,3,iregion,j)/twork(k,ltype,1,iregion,j)
                      twork(k,ltype,4,iregion,j) = &
-                           sqrt(twork(k,ltype,4,iregion,j)/twork(k,ltype,1,iregion,j))
+                           sqrt(max(0.0, twork(k,ltype,4,iregion,j))/twork(k,ltype,1,iregion,j))
                      twork(k,ltype,5,iregion,j) = &
                            twork(k,ltype,5,iregion,j)/twork(k,ltype,1,iregion,j)
                      twork(k,ltype,6,iregion,j) = &
@@ -1009,7 +1062,7 @@ module conmon_process_time_data
                if(twork(k,ntype_t+1,1,iregion,j) >=1.0) then
                   twork(k,ntype_t+1,3,iregion,j) = twork(k,ntype_t+1,3,iregion,j)/&
                                     twork(k,ntype_t+1,1,iregion,j)
-                  twork(k,ntype_t+1,4,iregion,j)=sqrt(twork(k,ntype_t+1,4,iregion,j)/&
+                  twork(k,ntype_t+1,4,iregion,j)=sqrt(max(0.0, twork(k,ntype_t+1,4,iregion,j))/&
                                     twork(k,ntype_t+1,1,iregion,j))
                   twork(k,ntype_t+1,5,iregion,j)=twork(k,ntype_t+1,5,iregion,j)/&
                                     twork(k,ntype_t+1,1,iregion,j)
@@ -1043,7 +1096,7 @@ module conmon_process_time_data
                      uvwork(k,ltype,3,iregion,j) = &
                            uvwork(k,ltype,3,iregion,j)/uvwork(k,ltype,1,iregion,j)
                      uvwork(k,ltype,4,iregion,j) = &
-                           sqrt(uvwork(k,ltype,4,iregion,j)/uvwork(k,ltype,1,iregion,j))
+                           sqrt(max(0.0, uvwork(k,ltype,4,iregion,j))/uvwork(k,ltype,1,iregion,j))
                      uvwork(k,ltype,5,iregion,j) = &
                            uvwork(k,ltype,5,iregion,j)/uvwork(k,ltype,1,iregion,j)
                      uvwork(k,ltype,6,iregion,j) = &
@@ -1055,18 +1108,18 @@ module conmon_process_time_data
                      uwork(k,ltype,3,iregion,j) = &
                            uwork(k,ltype,3,iregion,j)/uvwork(k,ltype,1,iregion,j)
                      uwork(k,ltype,4,iregion,j) = &
-                           sqrt(uwork(k,ltype,4,iregion,j)/uvwork(k,ltype,1,iregion,j))
+                           sqrt(max(0.0, uwork(k,ltype,4,iregion,j))/uvwork(k,ltype,1,iregion,j))
                      vwork(k,ltype,3,iregion,j) = &
                            vwork(k,ltype,3,iregion,j)/uvwork(k,ltype,1,iregion,j)
                      vwork(k,ltype,4,iregion,j) = &
-                           sqrt(vwork(k,ltype,4,iregion,j)/uvwork(k,ltype,1,iregion,j))
+                           sqrt(max(0.0, vwork(k,ltype,4,iregion,j))/uvwork(k,ltype,1,iregion,j))
                   endif
                enddo
 
                if(uvwork(k,ntype_uv+1,1,iregion,j) >=1.0) then
                   uvwork(k,ntype_uv+1,3,iregion,j)=uvwork(k,ntype_uv+1,3,iregion,j)&
                                   /uvwork(k,ntype_uv+1,1,iregion,j)
-                  uvwork(k,ntype_uv+1,4,iregion,j)=sqrt(uvwork(k,ntype_uv+1,4,iregion,j)&
+                  uvwork(k,ntype_uv+1,4,iregion,j)=sqrt(max(0.0, uvwork(k,ntype_uv+1,4,iregion,j))&
                                   /uvwork(k,ntype_uv+1,1,iregion,j))
                   uvwork(k,ntype_uv+1,5,iregion,j)=uvwork(k,ntype_uv+1,5,iregion,j)&
                                   /uvwork(k,ntype_uv+1,1,iregion,j)
@@ -1079,11 +1132,11 @@ module conmon_process_time_data
    
                   uwork(k,ntype_uv+1,3,iregion,j)=uwork(k,ntype_uv+1,3,iregion,j)&
                                   /uwork(k,ntype_uv+1,1,iregion,j)
-                  uwork(k,ntype_uv+1,4,iregion,j)=sqrt(uwork(k,ntype_uv+1,4,iregion,j)&
+                  uwork(k,ntype_uv+1,4,iregion,j)=sqrt(max(0.0, uwork(k,ntype_uv+1,4,iregion,j))&
                                   /uwork(k,ntype_uv+1,1,iregion,j))
                   vwork(k,ntype_uv+1,3,iregion,j)=vwork(k,ntype_uv+1,3,iregion,j)&
                                   /vwork(k,ntype_uv+1,1,iregion,j)
-                  vwork(k,ntype_uv+1,4,iregion,j)=sqrt(vwork(k,ntype_uv+1,4,iregion,j)&
+                  vwork(k,ntype_uv+1,4,iregion,j)=sqrt(max(0.0, vwork(k,ntype_uv+1,4,iregion,j))&
                                   /vwork(k,ntype_uv+1,1,iregion,j))
                endif
    

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_time.fd/process_time_data.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_time.fd/process_time_data.f90
@@ -49,7 +49,6 @@ module conmon_process_time_data
                    np,htop,hbot,nregion,mregion,&
                    rlatmin,rlatmax,rlonmin,rlonmax,iosubtype)
          implicit none
-         character(3) :: dtype
          integer :: nreal,n,ntype,np,nregion,mregion
          real(4),dimension(nreal,n) :: rdiag
          integer,dimension(:) :: iotype,iosubtype

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_time.fd/process_time_data.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_time.fd/process_time_data.f90
@@ -135,9 +135,9 @@ module conmon_process_time_data
       if( ntype_ps_use /= ntype_ps .or. ntype_q_use /= ntype_q .or. ntype_t_use /= ntype_t .or. &
            ntype_uv_use /= ntype_uv .or. ntype_gps_use /= ntype_gps ) then
          write(6,*) 'WARNING: ntype exceeds available metadata array sizes; truncating where needed.'
-          write(6,*) 'ntype_ps, ntype_q, ntype_t, ntype_uv, ntype_gps = ', &
+         write(6,*) 'ntype_ps, ntype_q, ntype_t, ntype_uv, ntype_gps = ', &
                   ntype_ps_use, ntype_q_use, ntype_t_use, ntype_uv_use, ntype_gps_use
-        end if
+      end if
 
       allocate( twork(np,ntype_t_dim,6,nregion,3), qwork(np,ntype_q_dim,6,nregion,3), &
                 uwork(np,ntype_uv_dim,6,nregion,3), vwork(np,ntype_uv_dim,6,nregion,3), &

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_time.fd/stas2ctl.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_time.fd/stas2ctl.f90
@@ -4,12 +4,12 @@
 !     Create the GrADS control file 
 !==========================================================
 
-subroutine creatstas_ctl(dtype,itype,ituse,nt,nc,nlev,nregion,nvar,&
+subroutine creatstas_ctl(dtype,itype,ituse,nc,nlev,nregion,nvar,&
                               region,rlatmin,rlatmax,rlonmin,rlonmax,isubtype)
    implicit none
 
-   integer nregion,nt,nlev,nc,i,icc,nvar
-   integer,dimension(nt):: itype,ituse,isubtype
+   integer nregion,nlev,nc,i,icc,nvar
+   integer,dimension(nc):: itype,ituse,isubtype
    character(7) dtype
    character(20) fileo
    character(40),dimension(nregion) :: region

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_time.fd/stas_time.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_time.fd/stas_time.f90
@@ -1,5 +1,13 @@
 !! the subroutine is to calculate the statistics
 
+module stas_time_mod
+
+   implicit none
+   private
+   public :: stascal
+
+contains
+
 subroutine stascal(dtype,rdiag,nreal,n,iotype,varqc,ntype,work,worku,&
                    workv,np,ptop,pbot,nregion,mregion,&
                    rlatmin,rlatmax,rlonmin,rlonmax,iosubtype)
@@ -7,18 +15,18 @@ subroutine stascal(dtype,rdiag,nreal,n,iotype,varqc,ntype,work,worku,&
    implicit none
 
    real(4),dimension(nreal,n) :: rdiag
-   real(4),dimension(100,2) :: varqc
-   real(4),dimension(np,100,6,nregion,3) :: work,worku,workv
+   real(4),dimension(:,:) :: varqc
+   real(4),dimension(:,:,:,:,:) :: work,worku,workv
    real(4),dimension(np) :: ptop,pbot
    real(4),dimension(mregion):: rlatmin,rlatmax,rlonmin,rlonmax
 
    character(3) :: dtype
   
-   integer,dimension(100) :: iotype,iosubtype
    integer itype,isubtype,ilat,ilon,ipress,iqc,iuse,imuse
    integer iwgt,ierr1,ierr2,ierr3,iobg,iobgu,iobgv,iqsges
    integer iobsu,iobsv,i,nregion,mregion,np,n,nreal,k,j
-   integer ltype,ntype,intype,insubtype,nn
+   integer ltype,ntype,intype,insubtype,nn,ntype_eff
+   integer,dimension(:) :: iotype,iosubtype
    real cg_term,pi,tiny
    real valu,valv,val,val2,gesu,gesv,spdb,exp_arg,arg
    real ress,ressu,ressv,valqc,term,wgross,cg_t,wnotgross
@@ -31,7 +39,8 @@ subroutine stascal(dtype,rdiag,nreal,n,iotype,varqc,ntype,work,worku,&
    pi=acos(-1.0)
    cg_term=sqrt(2.0*pi)/2.0
    tiny=1.0e-10
-
+   ntype_eff = min( ntype, size(iotype), size(iosubtype), size(varqc,1), &
+                    size(work,2), size(worku,2), size(workv,2) )
  
    do i=1,n
       if(trim(dtype) ==  ' uv') then
@@ -63,7 +72,7 @@ subroutine stascal(dtype,rdiag,nreal,n,iotype,varqc,ntype,work,worku,&
       endif
 
 !     print *,rdiag(itype,i),rdiag(ierr1,i),rdiag(ierr3,i),rdiag(imuse,i),nn
-      do ltype=1,ntype
+      do ltype=1,ntype_eff
          intype=int(rdiag(itype,i))
          insubtype=int(rdiag(isubtype,i))
           
@@ -124,4 +133,6 @@ subroutine stascal(dtype,rdiag,nreal,n,iotype,varqc,ntype,work,worku,&
 
 
    return
-end
+end subroutine stascal
+
+end module stas_time_mod

--- a/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_time.fd/stas_time_gps.f90
+++ b/src/Conventional_Monitor/nwprod/conmon_shared/sorc/conmon_time.fd/stas_time_gps.f90
@@ -1,24 +1,22 @@
 !! the subroutine is to calculate the statistics for gps data
 
-subroutine stascal_gps(dtype,rdiag,nreal,n,iotype,varqc,ntype,work,&
+subroutine stascal_gps(rdiag,nreal,n,iotype,varqc,ntype,work,&
                    np,htop,hbot,nregion,mregion,&
                    rlatmin,rlatmax,rlonmin,rlonmax,iosubtype)
 
    implicit none
 
    real(4),dimension(nreal,n) :: rdiag
-   real(4),dimension(100,2) :: varqc
-   real(4),dimension(np,100,6,nregion,3) :: work
+   real(4),dimension(:,:) :: varqc
+   real(4),dimension(:,:,:,:,:) :: work
    real(4),dimension(np) :: htop,hbot
    real(4),dimension(mregion):: rlatmin,rlatmax,rlonmin,rlonmax
-
-   character(3) :: dtype
   
-   integer,dimension(100) :: iotype,iosubtype
+   integer,dimension(:) :: iotype,iosubtype
    integer itype,isubtype,ilat,ilon,iheight,iqc,iuse,imuse
    integer iwgt,ierr1,ierr2,ierr3,iobg,iobgu,iobgv,iqsges
    integer iobsu,iobsv,i,nregion,mregion,np,n,nreal,k,j
-   integer ltype,ntype,intype,insubtype,nn, test_height
+   integer ltype,ntype,intype,insubtype,nn, test_height, ntype_eff
    real cg_term,pi,tiny
    real val,val2,exp_arg,arg
    real ress,valqc,term,wgross,cg_t,wnotgross
@@ -31,6 +29,7 @@ subroutine stascal_gps(dtype,rdiag,nreal,n,iotype,varqc,ntype,work,&
    pi=acos(-1.0)
    cg_term=sqrt(2.0*pi)/2.0
    tiny=1.0e-10
+   ntype_eff = min( ntype, size(iotype), size(iosubtype), size(varqc,1), size(work,2) )
 
  
    print *,'--> stascal_gps'
@@ -53,7 +52,7 @@ subroutine stascal_gps(dtype,rdiag,nreal,n,iotype,varqc,ntype,work,&
          if(rdiag(ierr3,i) >tiny) nn=3
       endif
 
-      do ltype=1,ntype
+      do ltype=1,ntype_eff
          intype=int(rdiag(itype,i))
          insubtype=int(rdiag(isubtype,i))
           


### PR DESCRIPTION
This PR accomplishes these things:

- Eliminate all remaining compiler warnings in GSI-monitor repo when building the executabes in "Debug" mode.  Most of the warnings were from unused variables.
- Fix all run-time failures in executables built in "Debug" mode.  Generally these were seg faults caused by array overruns.  Executables built in "Release" mode did not experience these failures.
- Add missing support for ursa to the `parm/Mon_config` and module files as well as the ConMon's data extraction script.
- Increase wall clock time for the data extraction job.  The run time is much longer than it probably should be and I'll open a new issue to address that.

Testing was done on both ursa and wcoss2.  Testing on ursa was done as part of development using a small sample of GDAS data.  On wcoss2 executables built in both "Debug" and "Release" modes have been tested over separate 3-day periods using operational GDAS data.  Results were nominal.


Closes #216 