### PR TITLE
Remove s4 and jet machines from GSI-Monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ GSI Monitoring Tools
 
 These tools monitor the Gridpoint Statistical Interpolation (GSI) package's data assimiliation, detecting 
 and reporting missing data sources, low observational counts, and high penalty values.  These machines 
-are supported:  wcoss2, hera, hercules, orion, jet, s4.
+are supported:  wcoss2, hera, hercules, orion, ursa.
 
 Suite includes:
 ```

--- a/parm/Mon_config
+++ b/parm/Mon_config
@@ -25,14 +25,8 @@ export MY_MACHINE=$machine_id
 #---------------------------------------------------
 #  Load modules from stack
 #
-#  Note:  I'm intentionally not including s4 and jet for the moment.
-#         I don't have access to those machines so I can't test the
-#         run-time modules.  If the run-time mod idea passes muster
-#         then I'll open an issue for the change to those machines.
-#
 if [[ $MY_MACHINE = "wcoss2" || $MY_MACHINE = "hera" || $MY_MACHINE = "orion" || \
-      $MY_MACHINE = "hercules" || $MY_MACHINE = "s4" || $MY_MACHINE = "jet" || \
-      $MY_MACHINE = "ursa" ]]; then
+      $MY_MACHINE = "hercules" || $MY_MACHINE = "ursa" ]]; then
    source $DIR_ROOT/ush/module-setup.sh
    module use $DIR_ROOT/modulefiles
    module load ${MACHINE_ID}.${COMPILER}-run
@@ -40,37 +34,6 @@ if [[ $MY_MACHINE = "wcoss2" || $MY_MACHINE = "hera" || $MY_MACHINE = "orion" ||
 fi
 
 case $MY_MACHINE in
-   s4)
-      export SUB=/usr/bin/sbatch
-      export SERVICE_PARTITION="serial"
-      tankdir="/data/users/$USER/monitor"
-      ptmp="/scratch/users/$USER"
-      stmp="/scratch/users/$USER"
-      queue=""
-      project=""
-      account="star"
-
-      #rstprod data is not allowed on S4
-      CHGRP_CMD=echo
-      ;;
-           
-   jet)
-      export SUB=/apps/slurm/default/bin/sbatch
-      export SERVICE_PARTITION="service"
-      account="nesdis-rdo2"
-
-      tankdir="/lfs1/NESDIS/nesdis-rdo2/$USER/monitor"
-      ptmp="/lfs1/NESDIS/nesdis-rdo2/$USER/para/ptmp"
-      stmp="/lfs1/NESDIS/nesdis-rdo2/$USER/para/stmp"
-      export BATCH_PARTITION="xjet"
-
-      export PARTITION_OZNMON=${PARTITION_OZNMON:-${BATCH_PARTITION}}
-
-      queue=""
-      project=""
-
-      ;;
-
    hera)
       export SUB=/apps/slurm/default/bin/sbatch
       export SERVICE_PARTITION="service"

--- a/src/Conventional_Monitor/data_extract/ush/ConMon_DE.sh
+++ b/src/Conventional_Monitor/data_extract/ush/ConMon_DE.sh
@@ -225,8 +225,7 @@ if [ -s $cnvstat  -a -s $pgrbf00 -a -s $pgrbf06 ]; then
          rm -f ${logfile}
       fi
 
-      if [[ $MY_MACHINE = "hera" || $MY_MACHINE = "s4" ||
-            $MY_MACHINE = "orion" || $MY_MACHINE = "hercules" ]]; then
+      if [[ $MY_MACHINE = "hera" || $MY_MACHINE = "orion" || $MY_MACHINE = "hercules" ]]; then
          $SUB -A $ACCOUNT --ntasks=1 --time=00:30:00 \
 		-p ${SERVICE_PARTITION} -J ${jobname} -o $C_LOGDIR/DE.${PDY}.${CYC}.log \
 		${HOMEgdas_conmon}/jobs/JGDAS_ATMOS_CONMON
@@ -236,11 +235,6 @@ if [ -s $cnvstat  -a -s $pgrbf00 -a -s $pgrbf06 ]; then
 		-J ${jobname} -o $C_LOGDIR/DE.${PDY}.${CYC}.log \
 		${HOMEgdas_conmon}/jobs/JGDAS_ATMOS_CONMON
 
-      elif [[ $MY_MACHINE = "jet" ]]; then
-         $SUB -A $ACCOUNT -ntasks=1 --time=00:30:00 --mem=5000 \
-		-p ${SERVICE_PARTITION} -J ${jobname} -o $C_LOGDIR/DE.${PDY}.${CYC}.log \
-		${HOMEgdas_conmon}/jobs/JGDAS_ATMOS_CONMON
-      
       elif [[ $MY_MACHINE = "wcoss2" ]]; then
         $SUB -V -q $JOB_QUEUE -A $ACCOUNT -o ${logfile} -e ${logfile} -l walltime=2:15:00 -N ${jobname} \
 		-l select=1:mem=8gb ${HOMEgdas_conmon}/jobs/JGDAS_ATMOS_CONMON

--- a/src/Conventional_Monitor/data_extract/ush/ConMon_DE_rgn.sh
+++ b/src/Conventional_Monitor/data_extract/ush/ConMon_DE_rgn.sh
@@ -259,7 +259,7 @@ if [[ -e ${cnvstat} ]]; then
       rm -f ${logfile}
    fi
 
-   if [[ ${MY_MACHINE} = "hera" || ${MY_MACHINE} = "orion" ]]; then
+   if [[ ${MY_MACHINE} = "hera" || ${MY_MACHINE} = "orion" || ${MY_MACHINE} = "hercules" ]]; then
       ${SUB} -A ${ACCOUNT} --ntasks=1 --time=00:30:00 \
   		-p ${SERVICE_PARTITION} -J ${jobname} -o ${C_LOGDIR}/DE.${PDY}.${CYC}.log \
 		${HOMEnam_conmon}/jobs/JNAM_CONMON

--- a/src/Conventional_Monitor/data_extract/ush/ConMon_DE_rgn.sh
+++ b/src/Conventional_Monitor/data_extract/ush/ConMon_DE_rgn.sh
@@ -259,16 +259,11 @@ if [[ -e ${cnvstat} ]]; then
       rm -f ${logfile}
    fi
 
-   if [[ ${MY_MACHINE} = "hera" || ${MY_MACHINE} = "s4" || ${MY_MACHINE} = "orion" ]]; then
+   if [[ ${MY_MACHINE} = "hera" || ${MY_MACHINE} = "orion" ]]; then
       ${SUB} -A ${ACCOUNT} --ntasks=1 --time=00:30:00 \
   		-p ${SERVICE_PARTITION} -J ${jobname} -o ${C_LOGDIR}/DE.${PDY}.${CYC}.log \
 		${HOMEnam_conmon}/jobs/JNAM_CONMON
 
-   elif [[ ${MY_MACHINE} = "jet" ]]; then
-      ${SUB} -A ${ACCOUNT} -ntasks=1 --time=00:30:00 --mem=5000 \
-		-p ${SERVICE_PARTITION} -J ${jobname} -o ${C_LOGDIR}/DE.${PDY}.${CYC}.log \
-		${HOMEnam_conmon}/jobs/JNAM_CONMON
-      
    elif [[ ${MY_MACHINE} = "wcoss2" ]]; then
       ${SUB} -V -q ${JOB_QUEUE} -A ${ACCOUNT} -o ${logfile} -e ${logfile} -l walltime=30:00 \
   	      -N ${jobname} -l select=1:mem=5000M ${HOMEnam_conmon}/jobs/JNAM_CONMON

--- a/src/Conventional_Monitor/image_gen/ush/mk_horz_hist.sh
+++ b/src/Conventional_Monitor/image_gen/ush/mk_horz_hist.sh
@@ -55,9 +55,7 @@
       rm -f ${errfile}
    fi
 
-   if [[ $MY_MACHINE == "hera" || $MY_MACHINE == "s4" || 
-         $MY_MACHINE == "jet" || $MY_MACHINE == "orion" || 
-         $MY_MACHINE == "hercules" ]]; then
+   if [[ $MY_MACHINE == "hera" || $MY_MACHINE == "orion" || $MY_MACHINE == "hercules" ]]; then
       ${SUB} -A ${ACCOUNT} --ntasks=1 --time=00:20:00 \
 		-p ${SERVICE_PARTITION} -J ${jobname} -o ${logfile} ${plot_hist}
 
@@ -83,9 +81,7 @@
       rm -f ${errfile}
    fi
 
-   if [[ $MY_MACHINE == "hera" || $MY_MACHINE == "s4" ||
-         $MY_MACHINE == "jet" || $MY_MACHINE == "orion" ||
-         $MY_MACHINE == "hercules" ]]; then
+   if [[ $MY_MACHINE == "hera" || $MY_MACHINE == "orion" || $MY_MACHINE == "hercules" ]]; then
       ${SUB} -A ${ACCOUNT} --ntasks=1 --time=00:20:00 \
 		-p ${SERVICE_PARTITION} -J ${jobname} -o ${logfile} ${plot_horz}
 
@@ -111,9 +107,7 @@
       rm -f ${errfile}
    fi
 
-   if [[ ${MY_MACHINE} == "hera" || ${MY_MACHINE} == "s4" || \
-         ${MY_MACHINE} == "jet" || ${MY_MACHINE} == "orion" ||
-         ${MY_MACHINE} == "hercules" ]]; then
+   if [[ ${MY_MACHINE} == "hera" || ${MY_MACHINE} == "orion" || ${MY_MACHINE} == "hercules" ]]; then
       ${SUB} -A ${ACCOUNT} --ntasks=1 --time=01:30:00 \
 	     -p ${SERVICE_PARTITION} -J ${jobname} -o ${logfile} ${plot_horz_uv}
 

--- a/src/Conventional_Monitor/image_gen/ush/mk_time_vert.sh
+++ b/src/Conventional_Monitor/image_gen/ush/mk_time_vert.sh
@@ -27,9 +27,7 @@ echo "--> mk_time_vert.sh"
       rm -f $errfile
    fi
 
-   if [[ ${MY_MACHINE} == "hera" || ${MY_MACHINE} == "s4" ||
-         ${MY_MACHINE} == "jet" || ${MY_MACHINE} == "orion" ||
-         ${MY_MACHINE} == "hercules" ]]; then
+   if [[ ${MY_MACHINE} == "hera" || ${MY_MACHINE} == "orion" || ${MY_MACHINE} == "hercules" ]]; then
       ${SUB} -A ${ACCOUNT} --ntasks=1 --time=00:15:00 \
                 -p ${SERVICE_PARTITION} -J ${jobname} -o ${logfile} ${pltfile}
 
@@ -56,9 +54,7 @@ echo "--> mk_time_vert.sh"
          rm -f $errfile
       fi
 
-      if [[ ${MY_MACHINE} == "hera" || ${MY_MACHINE} == "s4" ||
-            ${MY_MACHINE} == "jet" || ${MY_MACHINE} == "orion" ||
-            ${MY_MACHINE} == "hercules" ]]; then
+      if [[ ${MY_MACHINE} == "hera" || ${MY_MACHINE} == "orion" || ${MY_MACHINE} == "hercules" ]]; then
          if [[ ${type} == "uv" || ${type} == "u" || ${type} == "v" ]]; then
             walltime="02:30:00"
          else
@@ -101,9 +97,7 @@ echo "--> mk_time_vert.sh"
          rm -f $errfile
       fi
 
-      if [[ ${MY_MACHINE} == "hera" || ${MY_MACHINE} == "s4" || 
-            ${MY_MACHINE} == "jet" || ${MY_MACHINE} = "orion" ||
-            ${MY_MACHINE} == "hercules" ]]; then
+      if [[ ${MY_MACHINE} == "hera" || ${MY_MACHINE} = "orion" || ${MY_MACHINE} == "hercules" ]]; then
          if [[ ${type} == "uv" || ${type} == "u" || ${type} == "v" ]]; then
             walltime="00:50:00"
          else

--- a/src/Conventional_Monitor/image_gen/ush/mk_time_vert.sh
+++ b/src/Conventional_Monitor/image_gen/ush/mk_time_vert.sh
@@ -97,7 +97,7 @@ echo "--> mk_time_vert.sh"
          rm -f $errfile
       fi
 
-      if [[ ${MY_MACHINE} == "hera" || ${MY_MACHINE} = "orion" || ${MY_MACHINE} == "hercules" ]]; then
+      if [[ ${MY_MACHINE} == "hera" || ${MY_MACHINE} == "orion" || ${MY_MACHINE} == "hercules" ]]; then
          if [[ ${type} == "uv" || ${type} == "u" || ${type} == "v" ]]; then
             walltime="00:50:00"
          else

--- a/src/Minimization_Monitor/README
+++ b/src/Minimization_Monitor/README
@@ -2,7 +2,7 @@ README MinMon package
 
 The Minimization Monitor (MinMon) provides a means to visualize and report 
 on the performance of the GSI minimization function.  The package 
-is supported on wcoss2, hera, orion, hercules, cheyenne, jet, and s4 machines.
+is supported on wcoss2, hera, orion, hercules, and ursa machines.
 
 The package is organized in two main processes: data_extract and image_gen 
 (image generation).  The data extract piece is now located in the 

--- a/src/Ozone_Monitor/README
+++ b/src/Ozone_Monitor/README
@@ -3,8 +3,7 @@ README OznMon package
 The OznMon (ozone monitoring) package can be used to extract information
 from ozone diagnostic files and generate image plots to visualize the results.
 The package also may optionally perform data validation and error checking.
-The package is supported on wcoss2, hera, hercules, orion, cheyenne, jet, and s4 
-machines.
+The package is supported on wcoss2, hera, hercules, and orion machines.
 
 The package is organized in two processes, the data_extract and image_gen 
 (image generation).  There is also an nwprod directory, which contains the lower 

--- a/src/Ozone_Monitor/image_gen/ush/mk_horiz.sh
+++ b/src/Ozone_Monitor/image_gen/ush/mk_horiz.sh
@@ -50,8 +50,8 @@ for dsrc in ${data_source}; do
          list="obs anl obsanl"
       fi
 
-      if [[ ${MY_MACHINE} = "hera" || ${MY_MACHINE} = "jet" || ${MY_MACHINE} = "s4" ||
-            ${MY_MACHINE} = "orion" || ${MY_MACHINE} = "hercules" ]]; then
+      if [[ ${MY_MACHINE} = "hera" || ${MY_MACHINE} = "orion" || 
+	      ${MY_MACHINE} = "hercules" ]]; then
          echo "$ctr ${OZN_IG_SCRIPTS}/plot_horiz.sh $type $suffix '$list' $dsrc" >> $cmdfile
       else
          echo "${OZN_IG_SCRIPTS}/plot_horiz.sh $type $suffix '$list' $dsrc" >> $cmdfile
@@ -74,15 +74,10 @@ for dsrc in ${data_source}; do
    fi
 
 
-   if [[ ${MY_MACHINE} = "hera" || ${MY_MACHINE} = "s4" || ${MY_MACHINE} = "orion" ]]; then
+   if [[ ${MY_MACHINE} = "hera" || ${MY_MACHINE} = "orion" ]]; then
 
       $SUB --account ${ACCOUNT} -n $ctr  -o ${logf} -D . -J ${job} \
            --time=10 --wrap "srun -l --multi-prog ${cmdfile}"
-
-   elif [[ ${MY_MACHINE} = "jet" ]]; then
-
-      $SUB --account ${ACCOUNT} -n $ctr  -o ${logf} -D . -J ${job} \
-           --time=10 --partition=$PARTITION_OZNMON --wrap "srun -l --multi-prog ${cmdfile}"
 
    elif [[ $MY_MACHINE = "wcoss2" ]]; then
 

--- a/src/Ozone_Monitor/image_gen/ush/mk_horiz.sh
+++ b/src/Ozone_Monitor/image_gen/ush/mk_horiz.sh
@@ -74,7 +74,7 @@ for dsrc in ${data_source}; do
    fi
 
 
-   if [[ ${MY_MACHINE} = "hera" || ${MY_MACHINE} = "orion" ]]; then
+   if [[ ${MY_MACHINE} = "hera" || ${MY_MACHINE} = "orion" || ${MY_MACHINE} = "hercules" ]]; then
 
       $SUB --account ${ACCOUNT} -n $ctr  -o ${logf} -D . -J ${job} \
            --time=10 --wrap "srun -l --multi-prog ${cmdfile}"

--- a/src/Ozone_Monitor/image_gen/ush/mk_summary.sh
+++ b/src/Ozone_Monitor/image_gen/ush/mk_summary.sh
@@ -67,8 +67,7 @@ for ptype in ${data_source}; do
       #
       if [[ $type != "omi_aura" && $type != "gome_metop-a" && \
 	    $type != "gome_metop-b" && $type != "ompstc8_npp" && $type != "ompstc8_n20" ]]; then
-         if [[ ${MY_MACHINE} = "hera" || ${MY_MACHINE} = "jet" ||
-               ${MY_MACHINE} = "s4"   || ${MY_MACHINE} = "orion" ||
+         if [[ ${MY_MACHINE} = "hera" || ${MY_MACHINE} = "orion" ||
                ${MY_MACHINE} = "hercules" ]]; then
             echo "${ctr} ${OZN_IG_SCRIPTS}/plot_summary.sh $type $ptype" >> $cmdfile
          else
@@ -96,15 +95,10 @@ for ptype in ${data_source}; do
    fi
 
 
-   if [[ ${MY_MACHINE} = "hera" || ${MY_MACHINE} = "s4" || ${MY_MACHINE} = "orion" || 
+   if [[ ${MY_MACHINE} = "hera" || ${MY_MACHINE} = "orion" || 
          ${MY_MACHINE} = "hercules" ]]; then
 
       $SUB --account ${ACCOUNT} -n $ctr  -o ${logf} -D . -J ${job} --time=10 \
-           --wrap "srun -l --multi-prog ${cmdfile}"
-
-   elif [[ ${MY_MACHINE} = "jet" ]]; then
-
-      $SUB --account ${ACCOUNT} -n $ctr -p ${PARTITION_OZNMON} -o ${logf} -D . -J ${job} --time=10 \
            --wrap "srun -l --multi-prog ${cmdfile}"
 
    elif [[ $MY_MACHINE = "wcoss2" ]]; then

--- a/src/Ozone_Monitor/image_gen/ush/mk_time.sh
+++ b/src/Ozone_Monitor/image_gen/ush/mk_time.sh
@@ -49,8 +49,7 @@ for dsrc in ${data_source}; do
 
 >$cmdfile
    for type in ${SATYPE}; do
-      if [[ ${MY_MACHINE} = "hera" || ${MY_MACHINE} = "jet" || 
-            ${MY_MACHINE} = "s4"   || ${MY_MACHINE} = "orion" ||
+      if [[ ${MY_MACHINE} = "hera" || ${MY_MACHINE} = "orion" ||
             ${MY_MACHINE} = "hercules" ]]; then
          echo "${ctr} ${OZN_IG_SCRIPTS}/plot_time.sh $type $suffix '$list' $dsrc" >> $cmdfile
          ((ctr=ctr+1))
@@ -72,16 +71,11 @@ for dsrc in ${data_source}; do
       rm -f $errf
    fi
 
-   if [[ ${MY_MACHINE} = "hera" || ${MY_MACHINE} = "s4" ||
-         ${MY_MACHINE} = "orion" || ${MY_MACHINE} = "hercules" ]]; then
+   if [[ ${MY_MACHINE} = "hera" || ${MY_MACHINE} = "orion" || 
+	   ${MY_MACHINE} = "hercules" ]]; then
 
       $SUB --account ${ACCOUNT} -n $ctr  -o ${logf} -D . -J ${job} --time=10 \
            --wrap "srun -l --multi-prog ${cmdfile}"
-
-   elif [[ ${MY_MACHINE} = "jet" ]]; then
-
-      $SUB --account ${ACCOUNT} -n $ctr  -o ${logf} -D . -J ${job} --time=10 \
-           -p ${PARTITION_OZNMON} --wrap "srun -l --multi-prog ${cmdfile}"
 
    elif [[ $MY_MACHINE = "wcoss2" ]]; then
 

--- a/src/Radiance_Monitor/README
+++ b/src/Radiance_Monitor/README
@@ -4,7 +4,7 @@ The RadMon (radiance monitoring) package can be used to extract data from
 radiance diagnostic files and visualize the results by plotting the data using
 javascript or optionally GrADS.  The package also may optionally perform data 
 validation and error checking.  The package is supported on wcoss2, hera, 
-orion, hercules, cheyenne, jet, and s4 machines.
+orion, and hercules machines.
 
 The package is organized in two main processes, data_extract and image_gen 
 (image generation).  There is also an nwprod directory, which contains the lower 

--- a/src/Radiance_Monitor/image_gen/ush/mk_angle_plots.sh
+++ b/src/Radiance_Monitor/image_gen/ush/mk_angle_plots.sh
@@ -231,9 +231,7 @@ while [[ $ctr -le ${satarr_len} ]]; do
    # sbatch (slurm) requires a line number added
    # to the cmdfile
    #
-   if [[ ${MY_MACHINE} = "hera" || ${MY_MACHINE} = "jet" || 
-         ${MY_MACHINE} = "s4"   || ${MY_MACHINE} = "orion" ||
-         ${MY_MACHINE} = "hercules" ]]; then
+   if [[ ${MY_MACHINE} = "hera" || ${MY_MACHINE} = "orion" || ${MY_MACHINE} = "hercules" ]]; then
       echo "${itemctr} ${IG_SCRIPTS}/plot_angle.sh ${type} ${suffix} '${list}'" >> ${cmdfile}
    else
       echo "${IG_SCRIPTS}/plot_angle.sh ${type} ${suffix} '${list}'" >> ${cmdfile}
@@ -253,14 +251,9 @@ while [[ $ctr -le ${satarr_len} ]]; do
       errfile=${R_LOGDIR}/plot_angle_${suffix}_${jobctr}.err
 
       echo "TASKS= $tasks"
-      if [[ ${MY_MACHINE} = "hera" || ${MY_MACHINE} = "s4" || ${MY_MACHINE} = "orion" ||
-            ${MY_MACHINE} = "hercules" ]]; then
+      if [[ ${MY_MACHINE} = "hera" || ${MY_MACHINE} = "orion" || ${MY_MACHINE} = "hercules" ]]; then
          $SUB --account ${ACCOUNT} -n ${itemctr}  -o ${logfile} -D . -J ${jobname} --time=30:00 \
               --wrap "srun -l --multi-prog ${cmdfile}"
-
-      elif [[ ${MY_MACHINE} = "jet" ]]; then
-         $SUB --account ${ACCOUNT} -n ${itemctr}  -o ${logfile} -D . -J ${jobname} --time=30:00 \
-              -p ${BATCH_PARTITION} --wrap "srun -l --multi-prog ${cmdfile}"
 
       elif [[ $MY_MACHINE = "wcoss2" ]]; then
 	 if [[ $NUM_CYCLES -gt 140 ]]; then
@@ -316,10 +309,8 @@ for sat in ${big_satlist}; do
            -V -l walltime=60:00 -N ${jobname} ${cmdfile}
 
    #---------------------------------------------------
-   #  hera|jet|s4|orion|hercules, submit 1 job for each sat/list item
-   elif [[ $MY_MACHINE = "hera" || $MY_MACHINE = "jet" || \
-           $MY_MACHINE = "s4"   || $MY_MACHINE = "orion" ||
-           $MY_MACHINE = "hercules" ]]; then		
+   #  hera|orion|hercules, submit 1 job for each sat/list item
+   elif [[ $MY_MACHINE = "hera" || $MY_MACHINE = "orion" || $MY_MACHINE = "hercules" ]]; then		
 
       ii=0
       logfile=${R_LOGDIR}/plot_angle_${sat}.log
@@ -344,14 +335,6 @@ for sat in ${big_satlist}; do
       elif [[ $MY_MACHINE = "orion" || $MY_MACHINE = "hercules" ]]; then
          $SUB --account ${ACCOUNT} -n $ii  -o ${logfile} -D . -J ${jobname} --time=4:00:00 \
               -p ${SERVICE_PARTITION} --mem=0 --wrap "srun -l --multi-prog ${cmdfile}"
-
-      elif [[ $MY_MACHINE = "s4" ]]; then
-         $SUB --account ${ACCOUNT} -n $ii  -o ${logfile} -D . -J ${jobname} --time=4:00:00 \
-              --wrap "srun -l --multi-prog ${cmdfile}"
-
-      elif [[ $MY_MACHINE = "jet" ]]; then
-         $SUB --account ${ACCOUNT} -n $ii  -o ${logfile} -D . -J ${jobname} --time=4:00:00 \
-              -p ${BATCH_PARTITION} --wrap "srun -l --multi-prog ${cmdfile}"
 
       else
          $SUB --account ${ACCOUNT} -n $ii  -o ${logfile} -D . -J ${jobname} --time=4:00:00 \

--- a/src/Radiance_Monitor/image_gen/ush/mk_angle_plots.sh
+++ b/src/Radiance_Monitor/image_gen/ush/mk_angle_plots.sh
@@ -336,9 +336,6 @@ for sat in ${big_satlist}; do
          $SUB --account ${ACCOUNT} -n $ii  -o ${logfile} -D . -J ${jobname} --time=4:00:00 \
               -p ${SERVICE_PARTITION} --mem=0 --wrap "srun -l --multi-prog ${cmdfile}"
 
-      else
-         $SUB --account ${ACCOUNT} -n $ii  -o ${logfile} -D . -J ${jobname} --time=4:00:00 \
-              -p ${SERVICE_PARTITION} --wrap "srun -l --multi-prog ${cmdfile}"
       fi
 
    fi

--- a/src/Radiance_Monitor/image_gen/ush/mk_bcoef_plots.sh
+++ b/src/Radiance_Monitor/image_gen/ush/mk_bcoef_plots.sh
@@ -160,17 +160,13 @@ if [[ -e ${logfile} ]]; then
    rm ${logfile}
 fi
 
-if [[ $MY_MACHINE = "hera" || $MY_MACHINE = "s4" ]]; then
+if [[ $MY_MACHINE = "hera" ]]; then
    $SUB --account $ACCOUNT --ntasks=1 --mem=5g --time=1:00:00 -J ${jobname} \
         -o ${logfile} -D . $IG_SCRIPTS/plot_bcoef.sh 
 
 elif [[ $MY_MACHINE = "orion" || $MY_MACHINE = "hercules" ]]; then
    $SUB --account $ACCOUNT --ntasks=1 --mem=5g --time=20 -J ${jobname} \
         -p ${SERVICE_PARTITION} -o ${logfile} -D . $IG_SCRIPTS/plot_bcoef.sh 
-
-elif [[ $MY_MACHINE = "jet" ]]; then
-   $SUB --account $ACCOUNT --ntasks=1 --mem=5g --time=1:00:00 -J ${jobname} \
-        -p ${BATCH_PARTITION} -o ${logfile} -D . $IG_SCRIPTS/plot_bcoef.sh
 
 elif [[ $MY_MACHINE = "wcoss2" ]]; then
    $SUB -q $JOB_QUEUE -A $ACCOUNT -o ${logfile} -e $R_LOGDIR/plot_bcoef.err -V \

--- a/src/Radiance_Monitor/image_gen/ush/mk_bcor_plots.sh
+++ b/src/Radiance_Monitor/image_gen/ush/mk_bcor_plots.sh
@@ -186,9 +186,7 @@ rm -f ${logfile}
 
 ctr=0
 for sat in ${SATLIST}; do
-   if [[ $MY_MACHINE = "hera" || $MY_MACHINE = "jet" || 
-         $MY_MACHINE = "s4"   || $MY_MACHINE = "orion" ||
-         $MY_MACHINE = "hercules" ]]; then
+   if [[ $MY_MACHINE = "hera" || $MY_MACHINE = "orion" || $MY_MACHINE = "hercules" ]]; then
       echo "${ctr} $IG_SCRIPTS/plot_bcor.sh $sat $suffix '$plot_list'" >> $cmdfile
    else   
       echo "$IG_SCRIPTS/plot_bcor.sh $sat $suffix '$plot_list'" >> $cmdfile
@@ -205,17 +203,13 @@ else
    wall_tm="0:45"
 fi
 
-if [[ $MY_MACHINE = "hera" || $MY_MACHINE = "s4" ]]; then
+if [[ $MY_MACHINE = "hera" ]]; then
    $SUB --account ${ACCOUNT} -n $ctr  -o ${logfile} -D . -J ${jobname} \
         --time=2:00:00 --wrap "srun -l --multi-prog ${cmdfile}"
 
 elif [[ $MY_MACHINE = "orion" || $MY_MACHINE = "hercules" ]]; then
    $SUB --account ${ACCOUNT} -n $ctr  -o ${logfile} -D . -J ${jobname} --time=2:00:00 \
         -p ${SERVICE_PARTITION} --wrap "srun -l --multi-prog ${cmdfile}"
-
-elif [[ $MY_MACHINE = "jet" ]]; then
-   $SUB --account ${ACCOUNT} -n $ctr  -o ${logfile} -D . -J ${jobname} \
-        -p ${BATCH_PARTITION} --time=2:00:00 --wrap "srun -l --multi-prog ${cmdfile}"
 
 elif [[ $MY_MACHINE = "wcoss2" ]]; then
    $SUB -q $JOB_QUEUE -A $ACCOUNT -o ${logfile} -e ${R_LOGDIR}/plot_bcor_${suffix}.err \
@@ -245,9 +239,7 @@ for sat in ${bigSATLIST}; do
 
    ctr=0
    for var in $plot_list; do
-      if [[ $MY_MACHINE = "hera" || $MY_MACHINE = "jet" || 
-            $MY_MACHINE = "s4"   || $MY_MACHINE = "orion" ||
-            $MY_MACHINE = "hercules" ]]; then
+      if [[ $MY_MACHINE = "hera" || $MY_MACHINE = "orion" || $MY_MACHINE = "hercules" ]]; then
          echo "$ctr $IG_SCRIPTS/plot_bcor.sh $sat $var $var" >> $cmdfile
       else
          echo "$IG_SCRIPTS/plot_bcor.sh $sat $var $var" >> $cmdfile
@@ -263,17 +255,13 @@ for sat in ${bigSATLIST}; do
       wall_tm="1:00"
    fi
 
-   if [[ $MY_MACHINE = "hera" || $MY_MACHINE = "s4" ]]; then
+   if [[ $MY_MACHINE = "hera" ]]; then
       $SUB --account ${ACCOUNT} -n $ctr  -o ${logfile} -D . -J ${jobname} \
            --time=1:00:00 --wrap "srun -l --multi-prog ${cmdfile}"
 
    elif [[ $MY_MACHINE = "orion" || $MY_MACHINE = "hercules" ]]; then
       $SUB --account ${ACCOUNT} -n $ctr  -o ${logfile} -D . -J ${jobname} --time=1:00:00 \
            -p ${SERVICE_PARTITION} --wrap "srun -l --multi-prog ${cmdfile}"
-
-   elif [[ $MY_MACHINE = "jet" ]]; then
-      $SUB --account ${ACCOUNT} -n $ctr  -o ${logfile} -D . -J ${jobname} \
-           -p ${BATCH_PARTITION} --time=1:00:00 --wrap "srun -l --multi-prog ${cmdfile}"
 
    elif [[ $MY_MACHINE = "wcoss2" ]]; then
       $SUB -q $JOB_QUEUE -A $ACCOUNT -o ${logfile} -e ${R_LOGDIR}/plot_bcor_${suffix}.err \

--- a/src/Radiance_Monitor/image_gen/ush/mk_time_plots.sh
+++ b/src/Radiance_Monitor/image_gen/ush/mk_time_plots.sh
@@ -185,17 +185,13 @@ if [[ -e ${logfile} ]]; then
    rm ${logfile}
 fi
 
-if [[ ${MY_MACHINE} = "hera" || ${MY_MACHINE} = "s4" ]]; then
+if [[ ${MY_MACHINE} = "hera" ]]; then
    ${SUB} --account ${ACCOUNT}  --ntasks=1 --mem=5g --time=1:00:00 -J ${jobname} \
           -o ${logfile} ${IG_SCRIPTS}/plot_summary.sh
 
 elif [[ ${MY_MACHINE} = "orion" || ${MY_MACHINE} = "hercules" ]]; then
    ${SUB} --account ${ACCOUNT}  --ntasks=1 --mem=5g --time=20:00 -J ${jobname} \
           -o ${logfile} ${IG_SCRIPTS}/plot_summary.sh
-
-elif [[ ${MY_MACHINE} = "jet" ]]; then
-   ${SUB} --account ${ACCOUNT}  --ntasks=1 --mem=5g --time=1:00:00 -J ${jobname} \
-          --partition ${BATCH_PARTITION} -o ${logfile} ${IG_SCRIPTS}/plot_summary.sh
 
 elif [[ $MY_MACHINE = "wcoss2" ]]; then
    $SUB -q $JOB_QUEUE -A $ACCOUNT -o ${logfile} -e ${R_LOGDIR}/plot_summary.err -V \
@@ -246,9 +242,7 @@ fi
 ctr=0
 
 for sat in ${SATLIST}; do
-   if [[ ${MY_MACHINE} = "hera" || ${MY_MACHINE} = "jet" || 
-         ${MY_MACHINE} = "s4"   || ${MY_MACHINE} = "orion" ||
-         ${MY_MACHINE} = "hercules" ]]; then
+   if [[ ${MY_MACHINE} = "hera" || ${MY_MACHINE} = "orion" || ${MY_MACHINE} = "hercules" ]]; then
       echo "${ctr} $IG_SCRIPTS/plot_time.sh $sat $suffix '$list'" >> $cmdfile
    else
       echo "$IG_SCRIPTS/plot_time.sh $sat $suffix '$list'" >> $cmdfile
@@ -258,17 +252,13 @@ done
 chmod 755 $cmdfile
 
 
-if [[ $MY_MACHINE = "hera" || $MY_MACHINE = "s4" ]]; then
+if [[ $MY_MACHINE = "hera" ]]; then
    $SUB --account ${ACCOUNT} -n ${ctr}  -o ${logfile} -D . -J ${jobname} --time=1:00:00 \
         --wrap "srun -l --multi-prog ${cmdfile}"
 
 elif [[ $MY_MACHINE = "orion" || $MY_MACHINE = "hercules" ]]; then
    $SUB --account ${ACCOUNT} -n ${ctr}  -o ${logfile} -D . -J ${jobname} --time=1:00:00 \
         -p $SERVICE_PARTITION --wrap "srun -l --multi-prog ${cmdfile}"
-
-elif [[ $MY_MACHINE = "jet" ]]; then
-   $SUB --account ${ACCOUNT} -n ${ctr}  -o ${logfile} -D . -J ${jobname} --time=1:00:00 \
-        -p ${BATCH_PARTITION} --wrap "srun -l --multi-prog ${cmdfile}"
 
 elif [[ $MY_MACHINE = "wcoss2" ]]; then
    $SUB -q $JOB_QUEUE -A $ACCOUNT -o ${logfile} -e ${R_LOGDIR}/plot_time_${suffix}.err -V \
@@ -299,9 +289,7 @@ for sat in ${bigSATLIST}; do
 
    ctr=0 
    for var in $list; do
-      if [[ ${MY_MACHINE} = "hera" || ${MY_MACHINE} = "jet" || 
-            ${MY_MACHINE} = "s4"   || ${MY_MACHINE} = "orion" ||
-            ${MY_MACHINE} = "hercules" ]]; then
+      if [[ ${MY_MACHINE} = "hera" || ${MY_MACHINE} = "orion" || ${MY_MACHINE} = "hercules" ]]; then
          echo "${ctr} $IG_SCRIPTS/plot_time.sh $sat $var $var" >> $cmdfile
       else
          echo "$IG_SCRIPTS/plot_time.sh $sat $var $var" >> $cmdfile
@@ -315,17 +303,13 @@ for sat in ${bigSATLIST}; do
       wall_tm="2:30"
    fi
 
-   if [[ $MY_MACHINE = "hera" || $MY_MACHINE = "s4" ]]; then
+   if [[ $MY_MACHINE = "hera" ]]; then
       $SUB --account ${ACCOUNT} -n ${ctr}  -o ${logfile} -D . -J ${jobname} --time=4:00:00 \
            --wrap "srun -l --multi-prog ${cmdfile}"
 
    elif [[ $MY_MACHINE = "orion" || $MY_MACHINE = "hercules" ]]; then
       $SUB --account ${ACCOUNT} -n ${ctr}  -o ${logfile} -D . -J ${jobname} --time=1:30:00 \
            -p $SERVICE_PARTITION --wrap "srun -l --multi-prog ${cmdfile}"
-
-   elif [[ $MY_MACHINE = "jet" ]]; then
-      $SUB --account ${ACCOUNT} -n ${ctr}  -o ${logfile} -D . -J ${jobname} --time=4:00:00 \
-           -p ${BATCH_PARTITION} --wrap "srun -l --multi-prog ${cmdfile}"
 
    elif [[ $MY_MACHINE = "wcoss2" ]]; then
       logfile=${R_LOGDIR}/plot_time_${sat}.log

--- a/src/Radiance_Monitor/parm/RadMon_user_settings
+++ b/src/Radiance_Monitor/parm/RadMon_user_settings
@@ -84,7 +84,7 @@ export USE_STATIC_SATYPE=${USE_STATIC_SATYPE:-1}
 #    for use iwth the operational data sets (GDAS,NDAS) where detection and 
 #    reporting of drifting channel(s) on specific sat/instrument sources is 
 #    desirable.  It is not normally necesary to apply this to parallels.  0 = off, 1 = on
-export DO_DATA_RPT=${DO_DATA_RPT:-0}
+export DO_DATA_RPT=${DO_DATA_RPT:-1}
 
 #
 #  MAIL_TO and MAIL_CC are the email addresses used to distribute warning messages.

--- a/src/Radiance_Monitor/parm/RadMon_user_settings
+++ b/src/Radiance_Monitor/parm/RadMon_user_settings
@@ -84,7 +84,7 @@ export USE_STATIC_SATYPE=${USE_STATIC_SATYPE:-1}
 #    for use iwth the operational data sets (GDAS,NDAS) where detection and 
 #    reporting of drifting channel(s) on specific sat/instrument sources is 
 #    desirable.  It is not normally necesary to apply this to parallels.  0 = off, 1 = on
-export DO_DATA_RPT=${DO_DATA_RPT:-1}
+export DO_DATA_RPT=${DO_DATA_RPT:-0}
 
 #
 #  MAIL_TO and MAIL_CC are the email addresses used to distribute warning messages.

--- a/ush/detect_machine.sh
+++ b/ush/detect_machine.sh
@@ -35,8 +35,6 @@ case $(hostname -f) in
   der*) MACHINE_ID=derecho ;; ### derecho[1-8]
   dec*) MACHINE_ID=derecho ;; ### decxxxx computing node
 
-  s4-submit.ssec.wisc.edu) MACHINE_ID=s4 ;; ### s4
-
   ip-*|compute-dy-*|processing-dy-*)
     case ${PW_CSP:-} in
       "aws" | "google" | "azure") MACHINE_ID=noaacloud ;;


### PR DESCRIPTION
The s4 and jet machines are no longer available for use.  This PR removes settings and job submissions for those machines.

Testing has been done using operational GFS data over the past 3 cycles on wcoss2.  No errors or problems have occurred in any of the 4 monitors.


Closes #218 