### PR TITLE
Speed up ConMon data extraction 

### DIFF
--- a/src/Conventional_Monitor/data_extract/ush/ConMon_DE.sh
+++ b/src/Conventional_Monitor/data_extract/ush/ConMon_DE.sh
@@ -231,12 +231,12 @@ if [ -s $cnvstat  -a -s $pgrbf00 -a -s $pgrbf06 ]; then
 		${HOMEgdas_conmon}/jobs/JGDAS_ATMOS_CONMON
      
       elif [[ $MY_MACHINE = "ursa" ]]; then
-         $SUB -A $ACCOUNT --ntasks=1 --time=01:30:00 \
+         $SUB -A $ACCOUNT --ntasks=1 --time=00:30:00 \
 		-J ${jobname} -o $C_LOGDIR/DE.${PDY}.${CYC}.log \
 		${HOMEgdas_conmon}/jobs/JGDAS_ATMOS_CONMON
 
       elif [[ $MY_MACHINE = "wcoss2" ]]; then
-        $SUB -V -q $JOB_QUEUE -A $ACCOUNT -o ${logfile} -e ${logfile} -l walltime=2:15:00 -N ${jobname} \
+        $SUB -V -q $JOB_QUEUE -A $ACCOUNT -o ${logfile} -e ${logfile} -l walltime=0:30:00 -N ${jobname} \
 		-l select=1:mem=8gb ${HOMEgdas_conmon}/jobs/JGDAS_ATMOS_CONMON
       fi
 

--- a/src/Conventional_Monitor/nwprod/gdas_conmon/scripts/exgdas_atmos_conmon.sh
+++ b/src/Conventional_Monitor/nwprod/gdas_conmon/scripts/exgdas_atmos_conmon.sh
@@ -229,21 +229,21 @@
       #
       time_vert_work=${C_DATA}/time_vert.${PDATE}
       horz_hist_work=${C_DATA}/horz_hist.${PDATE}
-      rm -rf ${time_vert_work} ${horz_hist_work}
-      mkdir -p ${time_vert_work} ${horz_hist_work}
+      rm -rf "${time_vert_work}" "${horz_hist_work}"
+      mkdir -p "${time_vert_work}" "${horz_hist_work}"
 
-      ${NCP} ${convinfo} ${time_vert_work}/convinfo
-      ${NCP} ${convinfo} ${horz_hist_work}/convinfo
-      ${NCP} ./diag_conv* ${time_vert_work}/.
-      ${NCP} ./diag_conv* ${horz_hist_work}/.
+      ${NCP} "${convinfo}" "${time_vert_work}/convinfo"
+      ${NCP} "${convinfo}" "${horz_hist_work}/convinfo"
+      ${NCP} ./diag_conv* "${time_vert_work}/."
+      ${NCP} ./diag_conv* "${horz_hist_work}/."
 
       time_vert_log=${C_DATA}/time_vert.${PDATE}.log
       horz_hist_log=${C_DATA}/horz_hist.${PDATE}.log
 
-      ( cd ${time_vert_work}; ${USHconmon}/time_vert.sh ) > ${time_vert_log} 2>&1 &
+      ( cd "${time_vert_work}" && "${USHconmon}/time_vert.sh" ) > "${time_vert_log}" 2>&1 &
       pid_time_vert=$!
 
-      ( cd ${horz_hist_work}; ${USHconmon}/horz_hist.sh ) > ${horz_hist_log} 2>&1 &
+      ( cd "${horz_hist_work}" && "${USHconmon}/horz_hist.sh" ) > "${horz_hist_log}" 2>&1 &
       pid_horz_hist=$!
 
       wait ${pid_time_vert}

--- a/src/Conventional_Monitor/nwprod/gdas_conmon/scripts/exgdas_atmos_conmon.sh
+++ b/src/Conventional_Monitor/nwprod/gdas_conmon/scripts/exgdas_atmos_conmon.sh
@@ -223,16 +223,34 @@
       #------------------------------------------------------------------
 
       #---------------------------------------
-      #  run the time-vert extraction script
+      #  Run the extraction scripts in parallel.
+      #  Each script uses fixed scratch filenames, so give them
+      #  separate work directories and stage the shared inputs.
       #
-      ${USHconmon}/time_vert.sh 
+      time_vert_work=${C_DATA}/time_vert.${PDATE}
+      horz_hist_work=${C_DATA}/horz_hist.${PDATE}
+      rm -rf ${time_vert_work} ${horz_hist_work}
+      mkdir -p ${time_vert_work} ${horz_hist_work}
+
+      ${NCP} ${convinfo} ${time_vert_work}/convinfo
+      ${NCP} ${convinfo} ${horz_hist_work}/convinfo
+      ${NCP} ./diag_conv* ${time_vert_work}/.
+      ${NCP} ./diag_conv* ${horz_hist_work}/.
+
+      time_vert_log=${C_DATA}/time_vert.${PDATE}.log
+      horz_hist_log=${C_DATA}/horz_hist.${PDATE}.log
+
+      ( cd ${time_vert_work}; ${USHconmon}/time_vert.sh ) > ${time_vert_log} 2>&1 &
+      pid_time_vert=$!
+
+      ( cd ${horz_hist_work}; ${USHconmon}/horz_hist.sh ) > ${horz_hist_log} 2>&1 &
+      pid_horz_hist=$!
+
+      wait ${pid_time_vert}
       rc_time_vert=$?
       echo "rc_time_vert = $rc_time_vert"
 
-      #---------------------------------------
-      #  run the horz-hist extraction script
-      #
-      ${USHconmon}/horz_hist.sh
+      wait ${pid_horz_hist}
       rc_horz_hist=$?
       echo "rc_horz_hist = $rc_horz_hist"
 


### PR DESCRIPTION
Improve performance of ConMon's data extraction by running the `time_vert.sh` and `horz_hist.sh` scripts as child sub-processes in dedicated spaces.  Heretofore the two scripts were run serially.  This change has significantly improved wall time performance reducing run times from an hour and change to ~15 min. on both ursa and wcoss2.

Testing has been done on wcoss2 using operational gfs data over the last 4 cycles.  Output is as expected and wall times are significantly improved.


Closes #220 